### PR TITLE
fix: skills portáveis como plugin via CLAUDE_PLUGIN_ROOT

### DIFF
--- a/.agents/skills/0.1-criar-skill/SKILL.md
+++ b/.agents/skills/0.1-criar-skill/SKILL.md
@@ -121,8 +121,8 @@ Regras ao gerar:
 Depois de salvar, rode:
 
 ```bash
-bash ferramentas/manutencao/sincronizar-skills.sh
-python3 ferramentas/manutencao/verificar_compatibilidade.py
+bash "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/manutencao/sincronizar-skills.sh"
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/manutencao/verificar_compatibilidade.py"
 ```
 
 ### Passo 7 — Explicar como usar

--- a/.agents/skills/0.2-preparar-ambiente/SKILL.md
+++ b/.agents/skills/0.2-preparar-ambiente/SKILL.md
@@ -64,16 +64,16 @@ Instalar o programa:
 curl -fsSL https://bun.sh/install | bash
 ```
 
-Instalar as dependências da ferramenta (use o caminho relativo e volte para a raiz depois):
+Instalar as dependências da ferramenta (entre na pasta da ferramenta e volte ao diretório de trabalho depois):
 
 ```bash
-cd ferramentas/pesquisa/vade-mecum && bun install
+cd "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum" && bun install
 ```
 
 Testar se funcionou:
 
 ```bash
-bun run ferramentas/pesquisa/vade-mecum/src/cli.ts buscar "dano moral" 3
+bun run "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum/src/cli.ts" buscar "dano moral" 3
 ```
 
 #### uv (para `buscar-tjpr`)
@@ -87,7 +87,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 Preparar a ferramenta:
 
 ```bash
-uv sync --project ferramentas/pesquisa/busca-tjpr
+uv sync --project "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/busca-tjpr"
 ```
 
 **Avise o usuário:** a primeira busca no TJPR baixa cerca de 400 MB de um navegador

--- a/.agents/skills/1.1-organizar-caso/SKILL.md
+++ b/.agents/skills/1.1-organizar-caso/SKILL.md
@@ -46,7 +46,7 @@ Pule este passo se os documentos já vierem separados em vários arquivos.
 Faça este passo **somente** quando o material for **um único PDF enorme** com muitos documentos colados dentro — situação típica de autos de processo exportados de uma vez do PJe ou Projudi. Nesse caso, dividir o arquivo em um PDF por documento facilita a leitura:
 
 ```bash
-python3 ferramentas/processamento/split-autos/split.py "<caminho-do-caso>/autos/integra.pdf"
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/processamento/split-autos/split.py" "<caminho-do-caso>/autos/integra.pdf"
 ```
 
 (Troque `integra.pdf` pelo nome real do PDF gigante.) O script grava os PDFs separados na mesma pasta. Depois, refaça a listagem do Passo 1.

--- a/.agents/skills/1.2-transcrever/SKILL.md
+++ b/.agents/skills/1.2-transcrever/SKILL.md
@@ -63,7 +63,7 @@ Se tudo foi encontrado, siga para o Passo 2.
 Execute o comando de transcrição com o caminho do arquivo de mídia:
 
 ```bash
-python3 ferramentas/processamento/transcrever/transcrever.py "<arquivo-de-midia>"
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/processamento/transcrever/transcrever.py" "<arquivo-de-midia>"
 ```
 
 O que o programa faz, por baixo dos panos:

--- a/.agents/skills/2.2-buscar-fontes/SKILL.md
+++ b/.agents/skills/2.2-buscar-fontes/SKILL.md
@@ -17,13 +17,13 @@ comandos abaixo.
 ### Passo 1 — Executar busca ampla
 
 ```bash
-bun run ferramentas/pesquisa/vade-mecum/src/cli.ts buscar "<consulta>" 5
+bun run "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum/src/cli.ts" buscar "<consulta>" 5
 ```
 
 ### Passo 1b — Se necessário, busca focada em legislação
 
 ```bash
-bun run ferramentas/pesquisa/vade-mecum/src/cli.ts legislacao "<consulta>" todos 3
+bun run "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum/src/cli.ts" legislacao "<consulta>" todos 3
 ```
 
 ### Passo 2 — Analisar e filtrar

--- a/.agents/skills/2.3-buscar-tjpr/SKILL.md
+++ b/.agents/skills/2.3-buscar-tjpr/SKILL.md
@@ -31,7 +31,7 @@ O motor do TJPR tem comportamento não-óbvio. Regras empíricas que você deve 
 ### Passo 1 — Primeira rodada: busca ampla (3–4 termos)
 
 ```bash
-uv run --project "ferramentas/pesquisa/busca-tjpr" \
+uv run --project "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/busca-tjpr" \
   python -m busca_tjpr "<consulta>" 1 2>&1 | grep -v '\"asctime\"'
 ```
 

--- a/.claude/skills/0.1-criar-skill/SKILL.md
+++ b/.claude/skills/0.1-criar-skill/SKILL.md
@@ -121,8 +121,8 @@ Regras ao gerar:
 Depois de salvar, rode:
 
 ```bash
-bash ferramentas/manutencao/sincronizar-skills.sh
-python3 ferramentas/manutencao/verificar_compatibilidade.py
+bash "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/manutencao/sincronizar-skills.sh"
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/manutencao/verificar_compatibilidade.py"
 ```
 
 ### Passo 7 — Explicar como usar

--- a/.claude/skills/0.2-preparar-ambiente/SKILL.md
+++ b/.claude/skills/0.2-preparar-ambiente/SKILL.md
@@ -64,16 +64,16 @@ Instalar o programa:
 curl -fsSL https://bun.sh/install | bash
 ```
 
-Instalar as dependências da ferramenta (use o caminho relativo e volte para a raiz depois):
+Instalar as dependências da ferramenta (entre na pasta da ferramenta e volte ao diretório de trabalho depois):
 
 ```bash
-cd ferramentas/pesquisa/vade-mecum && bun install
+cd "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum" && bun install
 ```
 
 Testar se funcionou:
 
 ```bash
-bun run ferramentas/pesquisa/vade-mecum/src/cli.ts buscar "dano moral" 3
+bun run "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum/src/cli.ts" buscar "dano moral" 3
 ```
 
 #### uv (para `buscar-tjpr`)
@@ -87,7 +87,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 Preparar a ferramenta:
 
 ```bash
-uv sync --project ferramentas/pesquisa/busca-tjpr
+uv sync --project "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/busca-tjpr"
 ```
 
 **Avise o usuário:** a primeira busca no TJPR baixa cerca de 400 MB de um navegador

--- a/.claude/skills/1.1-organizar-caso/SKILL.md
+++ b/.claude/skills/1.1-organizar-caso/SKILL.md
@@ -46,7 +46,7 @@ Pule este passo se os documentos já vierem separados em vários arquivos.
 Faça este passo **somente** quando o material for **um único PDF enorme** com muitos documentos colados dentro — situação típica de autos de processo exportados de uma vez do PJe ou Projudi. Nesse caso, dividir o arquivo em um PDF por documento facilita a leitura:
 
 ```bash
-python3 ferramentas/processamento/split-autos/split.py "<caminho-do-caso>/autos/integra.pdf"
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/processamento/split-autos/split.py" "<caminho-do-caso>/autos/integra.pdf"
 ```
 
 (Troque `integra.pdf` pelo nome real do PDF gigante.) O script grava os PDFs separados na mesma pasta. Depois, refaça a listagem do Passo 1.

--- a/.claude/skills/1.2-transcrever/SKILL.md
+++ b/.claude/skills/1.2-transcrever/SKILL.md
@@ -63,7 +63,7 @@ Se tudo foi encontrado, siga para o Passo 2.
 Execute o comando de transcrição com o caminho do arquivo de mídia:
 
 ```bash
-python3 ferramentas/processamento/transcrever/transcrever.py "<arquivo-de-midia>"
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/processamento/transcrever/transcrever.py" "<arquivo-de-midia>"
 ```
 
 O que o programa faz, por baixo dos panos:

--- a/.claude/skills/2.2-buscar-fontes/SKILL.md
+++ b/.claude/skills/2.2-buscar-fontes/SKILL.md
@@ -17,13 +17,13 @@ comandos abaixo.
 ### Passo 1 — Executar busca ampla
 
 ```bash
-bun run ferramentas/pesquisa/vade-mecum/src/cli.ts buscar "<consulta>" 5
+bun run "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum/src/cli.ts" buscar "<consulta>" 5
 ```
 
 ### Passo 1b — Se necessário, busca focada em legislação
 
 ```bash
-bun run ferramentas/pesquisa/vade-mecum/src/cli.ts legislacao "<consulta>" todos 3
+bun run "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum/src/cli.ts" legislacao "<consulta>" todos 3
 ```
 
 ### Passo 2 — Analisar e filtrar

--- a/.claude/skills/2.3-buscar-tjpr/SKILL.md
+++ b/.claude/skills/2.3-buscar-tjpr/SKILL.md
@@ -31,7 +31,7 @@ O motor do TJPR tem comportamento não-óbvio. Regras empíricas que você deve 
 ### Passo 1 — Primeira rodada: busca ampla (3–4 termos)
 
 ```bash
-uv run --project "ferramentas/pesquisa/busca-tjpr" \
+uv run --project "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/busca-tjpr" \
   python -m busca_tjpr "<consulta>" 1 2>&1 | grep -v '\"asctime\"'
 ```
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ bash ferramentas/manutencao/sincronizar-skills.sh
 A sincronização regenera os dois espelhos e roda o verificador de compatibilidade, que também roda
 no GitHub Actions.
 
+Ao escrever um comando de skill que chama um motor ou script do kit, prefixe o caminho com
+`${CLAUDE_PLUGIN_ROOT:-.}` — por exemplo,
+`bun run "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum/src/cli.ts" …`. Quando o kit roda
+como plugin instalado, a variável aponta para a raiz do plugin; dentro do repositório (Claude Code
+nível projeto ou Codex) ela fica vazia e o caminho cai para o diretório de trabalho. Assim o mesmo
+comando funciona nos dois contextos, sem depender de uma ferramenta de um fornecedor específico.
+
 ## Licença
 
 Salvo indicação em contrário, o código, os protocolos, as ferramentas, os templates e a

--- a/skills/0.1-criar-skill/SKILL.md
+++ b/skills/0.1-criar-skill/SKILL.md
@@ -121,8 +121,8 @@ Regras ao gerar:
 Depois de salvar, rode:
 
 ```bash
-bash ferramentas/manutencao/sincronizar-skills.sh
-python3 ferramentas/manutencao/verificar_compatibilidade.py
+bash "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/manutencao/sincronizar-skills.sh"
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/manutencao/verificar_compatibilidade.py"
 ```
 
 ### Passo 7 — Explicar como usar

--- a/skills/0.2-preparar-ambiente/SKILL.md
+++ b/skills/0.2-preparar-ambiente/SKILL.md
@@ -64,16 +64,16 @@ Instalar o programa:
 curl -fsSL https://bun.sh/install | bash
 ```
 
-Instalar as dependências da ferramenta (use o caminho relativo e volte para a raiz depois):
+Instalar as dependências da ferramenta (entre na pasta da ferramenta e volte ao diretório de trabalho depois):
 
 ```bash
-cd ferramentas/pesquisa/vade-mecum && bun install
+cd "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum" && bun install
 ```
 
 Testar se funcionou:
 
 ```bash
-bun run ferramentas/pesquisa/vade-mecum/src/cli.ts buscar "dano moral" 3
+bun run "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum/src/cli.ts" buscar "dano moral" 3
 ```
 
 #### uv (para `buscar-tjpr`)
@@ -87,7 +87,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 Preparar a ferramenta:
 
 ```bash
-uv sync --project ferramentas/pesquisa/busca-tjpr
+uv sync --project "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/busca-tjpr"
 ```
 
 **Avise o usuário:** a primeira busca no TJPR baixa cerca de 400 MB de um navegador

--- a/skills/1.1-organizar-caso/SKILL.md
+++ b/skills/1.1-organizar-caso/SKILL.md
@@ -46,7 +46,7 @@ Pule este passo se os documentos já vierem separados em vários arquivos.
 Faça este passo **somente** quando o material for **um único PDF enorme** com muitos documentos colados dentro — situação típica de autos de processo exportados de uma vez do PJe ou Projudi. Nesse caso, dividir o arquivo em um PDF por documento facilita a leitura:
 
 ```bash
-python3 ferramentas/processamento/split-autos/split.py "<caminho-do-caso>/autos/integra.pdf"
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/processamento/split-autos/split.py" "<caminho-do-caso>/autos/integra.pdf"
 ```
 
 (Troque `integra.pdf` pelo nome real do PDF gigante.) O script grava os PDFs separados na mesma pasta. Depois, refaça a listagem do Passo 1.

--- a/skills/1.2-transcrever/SKILL.md
+++ b/skills/1.2-transcrever/SKILL.md
@@ -63,7 +63,7 @@ Se tudo foi encontrado, siga para o Passo 2.
 Execute o comando de transcrição com o caminho do arquivo de mídia:
 
 ```bash
-python3 ferramentas/processamento/transcrever/transcrever.py "<arquivo-de-midia>"
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/processamento/transcrever/transcrever.py" "<arquivo-de-midia>"
 ```
 
 O que o programa faz, por baixo dos panos:

--- a/skills/2.2-buscar-fontes/SKILL.md
+++ b/skills/2.2-buscar-fontes/SKILL.md
@@ -17,13 +17,13 @@ comandos abaixo.
 ### Passo 1 — Executar busca ampla
 
 ```bash
-bun run ferramentas/pesquisa/vade-mecum/src/cli.ts buscar "<consulta>" 5
+bun run "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum/src/cli.ts" buscar "<consulta>" 5
 ```
 
 ### Passo 1b — Se necessário, busca focada em legislação
 
 ```bash
-bun run ferramentas/pesquisa/vade-mecum/src/cli.ts legislacao "<consulta>" todos 3
+bun run "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/vade-mecum/src/cli.ts" legislacao "<consulta>" todos 3
 ```
 
 ### Passo 2 — Analisar e filtrar

--- a/skills/2.3-buscar-tjpr/SKILL.md
+++ b/skills/2.3-buscar-tjpr/SKILL.md
@@ -31,7 +31,7 @@ O motor do TJPR tem comportamento não-óbvio. Regras empíricas que você deve 
 ### Passo 1 — Primeira rodada: busca ampla (3–4 termos)
 
 ```bash
-uv run --project "ferramentas/pesquisa/busca-tjpr" \
+uv run --project "${CLAUDE_PLUGIN_ROOT:-.}/ferramentas/pesquisa/busca-tjpr" \
   python -m busca_tjpr "<consulta>" 1 2>&1 | grep -v '\"asctime\"'
 ```
 


### PR DESCRIPTION
Os comandos das skills que chamam motores e scripts do kit usavam caminho relativo ao diretório de trabalho, o que quebrava quando o kit roda como plugin instalado (o CWD é a pasta do caso, não a raiz do repo). Prefixa os 10 comandos com ${CLAUDE_PLUGIN_ROOT:-.}: como plugin, aponta para a raiz do plugin; dentro do repo (Claude Code nível projeto ou Codex), a variável fica vazia e cai para o diretório atual, preservando o comportamento atual.

Regenera os espelhos (.claude/skills e skills) e documenta o padrão na seção de manutenção do README.