### PR TITLE
feat: administração de consumo e limite por usuário

### DIFF
--- a/ferramentas/manutencao/construir_indice_geo.py
+++ b/ferramentas/manutencao/construir_indice_geo.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Constrói o índice local de geolocalização por IP usado nos relatórios de acesso.
+
+Converte o CSV do DB-IP Lite em dois arquivos compactos, para que a consulta seja
+feita na própria máquina, sem enviar IP nenhum a serviço externo:
+
+    ranges.bin   faixas IPv4 ordenadas — 10 bytes por faixa (início, fim, local)
+    locais.tsv   tabela "país<TAB>estado", uma linha por local
+
+Só IPv4 entra, e a cidade é descartada: os IPs chegam mascarados em /24 nos logs, o
+que sustenta país e estado, não cidade. Faixas vizinhas com o mesmo local são unidas,
+o que reduz o índice em cerca de metade.
+
+Uso:
+
+    curl -sO https://download.db-ip.com/free/dbip-city-lite-AAAA-MM.csv.gz
+    sudo python3 construir_indice_geo.py dbip-city-lite-AAAA-MM.csv.gz /var/lib/dbip
+
+Fonte: DB-IP Lite (https://db-ip.com/db/download/ip-to-city-lite), licença CC BY 4.0 —
+a atribuição é obrigatória em qualquer publicação que use estes dados. A base é mensal;
+reconstrua de tempos em tempos para não trabalhar com faixas envelhecidas.
+"""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import struct
+import sys
+from pathlib import Path
+
+REGISTRO = struct.Struct("<IIH")  # início, fim, índice do local
+LIMITE_LOCAIS = 65_535            # o índice do local cabe em 2 bytes
+
+
+def para_inteiro(ip: str) -> int | None:
+    """Converte um IPv4 em inteiro. Devolve None para IPv6 ou lixo."""
+    partes = ip.split(".")
+    if len(partes) != 4:
+        return None
+    valor = 0
+    for parte in partes:
+        try:
+            octeto = int(parte)
+        except ValueError:
+            return None
+        if not 0 <= octeto <= 255:
+            return None
+        valor = (valor << 8) | octeto
+    return valor
+
+
+def construir(origem: Path, destino: Path) -> None:
+    destino.mkdir(parents=True, exist_ok=True)
+    locais: dict[tuple[str, str], int] = {}
+    faixas: list[tuple[int, int, int]] = []
+    ignoradas = 0
+
+    abrir = gzip.open if origem.suffix == ".gz" else open
+    with abrir(origem, "rt", encoding="utf-8", errors="replace", newline="") as arquivo:
+        for linha in csv.reader(arquivo):
+            if len(linha) < 5:
+                continue
+            inicio = para_inteiro(linha[0])
+            fim = para_inteiro(linha[1])
+            if inicio is None or fim is None:
+                ignoradas += 1
+                continue
+
+            pais = linha[3].strip() or "??"
+            estado = linha[4].strip()
+            chave = (pais, estado)
+            if chave not in locais:
+                if len(locais) >= LIMITE_LOCAIS:
+                    # Passou do que o índice de 2 bytes comporta: agrupa pelo país.
+                    chave = (pais, "")
+                    locais.setdefault(chave, len(locais))
+                else:
+                    locais[chave] = len(locais)
+            indice = locais[chave]
+
+            # Une a faixa anterior quando é contígua e aponta para o mesmo local.
+            if faixas and faixas[-1][2] == indice and faixas[-1][1] + 1 == inicio:
+                faixas[-1] = (faixas[-1][0], fim, indice)
+            else:
+                faixas.append((inicio, fim, indice))
+
+    faixas.sort(key=lambda f: f[0])
+
+    with (destino / "ranges.bin").open("wb") as saida:
+        for inicio, fim, indice in faixas:
+            saida.write(REGISTRO.pack(inicio, fim, indice))
+
+    ordenados = sorted(locais.items(), key=lambda item: item[1])
+    with (destino / "locais.tsv").open("w", encoding="utf-8") as saida:
+        for (pais, estado), _ in ordenados:
+            saida.write(f"{pais}\t{estado}\n")
+
+    tamanho = (destino / "ranges.bin").stat().st_size
+    print(f"Faixas IPv4 : {len(faixas):,}".replace(",", "."))
+    print(f"Locais      : {len(locais):,}".replace(",", "."))
+    print(f"Índice      : {tamanho / 1_048_576:.1f} MiB em {destino}")
+    if ignoradas:
+        print(f"Linhas IPv6 ou inválidas ignoradas: {ignoradas:,}".replace(",", "."))
+    print("\nFonte: DB-IP Lite (CC BY 4.0) — cite a atribuição ao publicar estes dados.")
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__)
+        return 1
+    origem = Path(sys.argv[1])
+    if not origem.exists():
+        print(f"CSV não encontrado: {origem}", file=sys.stderr)
+        return 1
+    construir(origem, Path(sys.argv[2]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ferramentas/manutencao/relatorio_acesso.py
+++ b/ferramentas/manutencao/relatorio_acesso.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Relatório de uso do site e do servidor MCP a partir dos logs do Caddy.
+
+Lê os arquivos JSON de acesso gravados por deploy/Caddyfile e resume volume,
+clientes e páginas em linguagem direta. Os IPs já chegam mascarados do Caddy
+(faixa /24), então este relatório conta faixas de rede, não pessoas.
+
+Uso, direto na VM:
+
+    sudo python3 relatorio_acesso.py /var/log/caddy/site.log
+    sudo python3 relatorio_acesso.py /var/log/caddy/mcp.log --desde hoje
+
+Uso, a partir da máquina local (sem copiar o log para cá):
+
+    gcloud compute ssh <instancia> --zone <zona> --command \\
+      'sudo python3 -' < ferramentas/manutencao/relatorio_acesso.py
+
+O filtro --desde aceita "hoje", "ontem" ou um número de horas ("24h").
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mmap
+import struct
+import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Índice local de geolocalização, gerado por construir_indice_geo.py. Se não existir,
+# o relatório apenas omite a seção de origem — nada é consultado fora da máquina.
+INDICE_GEO_PADRAO = Path("/var/lib/dbip")
+REGISTRO_GEO = struct.Struct("<IIH")
+
+# Requisições que inflam a contagem sem indicar leitura humana de conteúdo.
+EXTENSOES_ESTATICAS = (
+    ".css", ".js", ".svg", ".png", ".jpg", ".jpeg", ".webp",
+    ".ico", ".woff", ".woff2", ".ttf", ".map", ".xml", ".txt",
+)
+
+# User-Agents de robôs, scanners e monitoramento, separados do tráfego de interesse.
+# "l9scan"/"leakix" e afins são varredores de vulnerabilidade: batem em /.git/config,
+# /wp-admin e similares. Contá-los como visita infla o número de usuários.
+MARCAS_DE_ROBO = (
+    "bot", "crawler", "spider", "slurp", "curl", "wget",
+    "python-requests", "headless", "monitor", "uptime", "probe",
+    "scan", "leakix", "go-http-client", "httpx", "aiohttp", "okhttp", "libwww",
+)
+
+
+class IndiceGeo:
+    """Consulta país/estado de um IPv4 usando o índice local.
+
+    O arquivo é mapeado em memória e percorrido por busca binária: 2 milhões de
+    faixas cabem em 20 MiB e a consulta não carrega o índice inteiro na RAM, o que
+    importa numa máquina pequena.
+    """
+
+    def __init__(self, diretorio: Path):
+        self.locais: list[tuple[str, str]] = []
+        with (diretorio / "locais.tsv").open(encoding="utf-8") as arquivo:
+            for linha in arquivo:
+                pais, _, estado = linha.rstrip("\n").partition("\t")
+                self.locais.append((pais, estado))
+        self._arquivo = (diretorio / "ranges.bin").open("rb")
+        self._mapa = mmap.mmap(self._arquivo.fileno(), 0, access=mmap.ACCESS_READ)
+        self.total = len(self._mapa) // REGISTRO_GEO.size
+
+    @staticmethod
+    def _para_inteiro(ip: str) -> int | None:
+        partes = ip.split(".")
+        if len(partes) != 4:
+            return None
+        valor = 0
+        for parte in partes:
+            if not parte.isdigit() or not 0 <= int(parte) <= 255:
+                return None
+            valor = (valor << 8) | int(parte)
+        return valor
+
+    def localizar(self, ip: str) -> tuple[str, str] | None:
+        """Devolve (país, estado) ou None quando o IP não está em nenhuma faixa."""
+        numero = self._para_inteiro(ip)
+        if numero is None:
+            return None
+        baixo, alto = 0, self.total
+        while baixo < alto:
+            meio = (baixo + alto) // 2
+            inicio, fim, indice = REGISTRO_GEO.unpack_from(self._mapa, meio * REGISTRO_GEO.size)
+            if numero < inicio:
+                alto = meio
+            elif numero > fim:
+                baixo = meio + 1
+            else:
+                return self.locais[indice]
+        return None
+
+
+def abrir_indice_geo(caminho: Path) -> IndiceGeo | None:
+    """Carrega o índice se ele existir; caso contrário segue sem geolocalização."""
+    if not (caminho / "ranges.bin").exists() or not (caminho / "locais.tsv").exists():
+        return None
+    try:
+        return IndiceGeo(caminho)
+    except OSError:
+        return None
+
+
+def instante_de_corte(desde: str | None) -> datetime | None:
+    """Converte o filtro textual em um instante UTC, ou None se não houver filtro."""
+    if not desde:
+        return None
+    agora = datetime.now(timezone.utc)
+    termo = desde.strip().lower()
+    if termo == "hoje":
+        return agora.replace(hour=0, minute=0, second=0, microsecond=0)
+    if termo == "ontem":
+        return agora.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=1)
+    if termo.endswith("h"):
+        return agora - timedelta(hours=float(termo[:-1]))
+    raise ValueError(f'Filtro --desde não reconhecido: "{desde}" (use hoje, ontem ou 24h)')
+
+
+def eh_robo(user_agent: str) -> bool:
+    ua = user_agent.lower()
+    return any(marca in ua for marca in MARCAS_DE_ROBO)
+
+
+def eh_estatico(uri: str) -> bool:
+    caminho = uri.split("?", 1)[0].lower()
+    return caminho.endswith(EXTENSOES_ESTATICAS)
+
+
+def normalizar_pagina(uri: str) -> str:
+    """Junta /metodo e /metodo/ na mesma contagem — são a mesma página."""
+    caminho = uri.split("?", 1)[0]
+    return caminho.rstrip("/") or "/"
+
+
+def rotulo_de_cliente(user_agent: str) -> str:
+    """Agrupa o User-Agent em uma família legível, para não pulverizar a contagem."""
+    ua = user_agent.lower()
+    if "openai-mcp" in ua:
+        return "Codex (OpenAI)" if "codex" in ua else "ChatGPT (OpenAI)"
+    if "claude-code" in ua:
+        return "Claude Code"
+    # O connector remoto do claude.ai se identifica assim ao chamar o MCP.
+    if "claude-user" in ua:
+        return "Claude (claude.ai)"
+    if ua.startswith("claude") or "anthropic" in ua:
+        return "Claude (outro)"
+    if eh_robo(user_agent):
+        return "robô / monitoramento"
+    for nome, marca in (("Edge", "edg/"), ("Chrome", "chrome"), ("Firefox", "firefox"), ("Safari", "safari")):
+        if marca in ua:
+            return nome
+    return "outro"
+
+
+def abrir(caminho: Path):
+    """Abre o arquivo, ou a entrada padrão quando o caminho é '-'."""
+    if str(caminho) == "-":
+        return sys.stdin
+    return caminho.open(encoding="utf-8", errors="replace")
+
+
+def extrair_json(linha: str) -> dict | None:
+    """Isola o JSON da linha.
+
+    O journald prefixa cada linha com data, host e processo; o log do Caddy vem
+    limpo. Cortar a partir da primeira chave atende aos dois casos.
+    """
+    inicio = linha.find("{")
+    if inicio < 0:
+        return None
+    try:
+        return json.loads(linha[inicio:])
+    except json.JSONDecodeError:
+        return None
+
+
+def momento_do_registro(registro: dict) -> datetime | None:
+    """Lê o instante do evento: epoch no log do Caddy, ISO 8601 na telemetria."""
+    ts = registro.get("ts")
+    if isinstance(ts, (int, float)):
+        return datetime.fromtimestamp(ts, tz=timezone.utc)
+    if isinstance(ts, str):
+        try:
+            return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def carregar(caminho: Path, corte: datetime | None) -> tuple[list[dict], list[dict]]:
+    """Lê o log e separa os dois tipos de evento que sabemos interpretar.
+
+    Devolve (acessos, usos): requisições HTTP registradas pelo Caddy e chamadas de
+    ferramenta registradas pelo servidor MCP. Um arquivo costuma ter só um dos dois.
+    """
+    acessos, usos = [], []
+    arquivo = abrir(caminho)
+    try:
+        for linha in arquivo:
+            registro = extrair_json(linha)
+            if registro is None:
+                continue
+            eh_acesso = registro.get("msg") == "handled request"
+            eh_uso = registro.get("evento") == "uso_ferramenta"
+            if not (eh_acesso or eh_uso):
+                continue
+            momento = momento_do_registro(registro)
+            if momento is None:
+                continue
+            if corte and momento < corte:
+                continue
+            registro["_momento"] = momento
+            (acessos if eh_acesso else usos).append(registro)
+    finally:
+        if arquivo is not sys.stdin:
+            arquivo.close()
+    return acessos, usos
+
+
+def imprimir_secao(titulo: str, contagem: Counter, limite: int = 10, total: int | None = None) -> None:
+    if not contagem:
+        return
+    print(f"\n{titulo}")
+    print("-" * len(titulo))
+    for chave, valor in contagem.most_common(limite):
+        if total:
+            print(f"  {valor:6}  ({valor / total:5.1%})  {chave}")
+        else:
+            print(f"  {valor:6}  {chave}")
+    restantes = len(contagem) - limite
+    if restantes > 0:
+        print(f"  ... e mais {restantes} não listados")
+
+
+def relatorio_de_ferramentas(usos: list[dict]) -> None:
+    """Mostra quais ferramentas do acervo foram chamadas e quantas acharam algo."""
+    chamadas = Counter()
+    vazias = Counter()
+    falhas = Counter()
+    facetas = Counter()
+    duracoes: list[float] = []
+
+    for uso in usos:
+        ferramenta = uso.get("tool", "(desconhecida)")
+        chamadas[ferramenta] += 1
+        if uso.get("falhou"):
+            falhas[ferramenta] += 1
+        elif uso.get("achou") is False:
+            vazias[ferramenta] += 1
+        if isinstance(uso.get("ms"), (int, float)):
+            duracoes.append(float(uso["ms"]))
+        for campo in ("tribunal", "codigo"):
+            if uso.get(campo):
+                facetas[f"{campo}={uso[campo]}"] += 1
+
+    total = sum(chamadas.values())
+    sem_resultado = sum(vazias.values())
+
+    print("\nFERRAMENTAS DO ACERVO")
+    print("-" * 21)
+    print(f"  Chamadas       : {total}")
+    print(f"  Sem resultado  : {sem_resultado} ({sem_resultado / total:.1%})" if total else "")
+    if sum(falhas.values()):
+        print(f"  Chamadas inválidas: {sum(falhas.values())}")
+    if duracoes:
+        ordenadas = sorted(duracoes)
+        mediana = ordenadas[len(ordenadas) // 2]
+        print(f"  Tempo (mediana): {mediana:.1f} ms   (pior: {ordenadas[-1]:.1f} ms)")
+
+    print("\n  {:<22} {:>8} {:>14}".format("ferramenta", "chamadas", "sem resultado"))
+    for ferramenta, quantidade in chamadas.most_common():
+        vazio = vazias[ferramenta]
+        marca = "  ← revisar" if quantidade >= 5 and vazio / quantidade > 0.5 else ""
+        print(f"  {ferramenta:<22} {quantidade:>8} {vazio:>8} ({vazio / quantidade:4.0%}){marca}")
+
+    imprimir_secao("FILTROS USADOS", facetas)
+    print("\nO termo pesquisado não é registrado — só a ferramenta e se houve resultado.")
+
+
+def main() -> int:
+    analisador = argparse.ArgumentParser(
+        description="Resume os logs de acesso do Caddy (site e MCP).",
+    )
+    analisador.add_argument("log", type=Path, help="caminho do arquivo .log")
+    analisador.add_argument("--desde", help="hoje, ontem ou um número de horas (ex.: 24h)")
+    analisador.add_argument(
+        "--com-estaticos",
+        action="store_true",
+        help="inclui CSS, imagens e fontes na contagem de páginas",
+    )
+    analisador.add_argument(
+        "--geo",
+        default=str(INDICE_GEO_PADRAO),
+        help=f"diretório do índice de geolocalização (default: {INDICE_GEO_PADRAO})",
+    )
+    argumentos = analisador.parse_args()
+
+    if str(argumentos.log) != "-" and not argumentos.log.exists():
+        print(f"Arquivo não encontrado: {argumentos.log}", file=sys.stderr)
+        print("Na VM os logs ficam em /var/log/caddy/ e exigem sudo.", file=sys.stderr)
+        return 1
+
+    try:
+        corte = instante_de_corte(argumentos.desde)
+    except ValueError as erro:
+        print(erro, file=sys.stderr)
+        return 1
+
+    eventos, usos = carregar(argumentos.log, corte)
+    if not eventos and not usos:
+        janela = f" desde {argumentos.desde}" if argumentos.desde else ""
+        origem = "entrada padrão" if str(argumentos.log) == "-" else argumentos.log.name
+        print(f"Nenhum evento reconhecido em {origem}{janela}.")
+        return 0
+
+    # Telemetria do servidor MCP: relatório próprio, não tem requisição HTTP para resumir.
+    if usos and not eventos:
+        primeiro = min(u["_momento"] for u in usos)
+        ultimo = max(u["_momento"] for u in usos)
+        print("=" * 60)
+        print("RELATÓRIO DE USO DAS FERRAMENTAS")
+        print("=" * 60)
+        print(f"Janela      : {primeiro:%d/%m/%Y %H:%M} a {ultimo:%d/%m/%Y %H:%M} (UTC)")
+        relatorio_de_ferramentas(usos)
+        return 0
+
+    clientes = Counter()
+    faixas = Counter()
+    paginas = Counter()
+    horas = Counter()
+    status = Counter()
+    sessoes_mcp = set()
+    requisicoes_humanas = 0
+
+    for evento in eventos:
+        requisicao = evento["request"]
+        cabecalhos = requisicao.get("headers", {})
+        user_agent = (cabecalhos.get("User-Agent") or ["(sem identificação)"])[0]
+        uri = requisicao.get("uri", "/")
+
+        status[evento.get("status", 0)] += 1
+        clientes[rotulo_de_cliente(user_agent)] += 1
+
+        sessao = cabecalhos.get("Mcp-Session-Id")
+        if sessao:
+            sessoes_mcp.add(sessao[0])
+
+        if eh_robo(user_agent):
+            continue
+        if not argumentos.com_estaticos and eh_estatico(uri):
+            continue
+
+        requisicoes_humanas += 1
+        faixas[requisicao.get("client_ip", "?")] += 1
+        paginas[normalizar_pagina(uri)] += 1
+        horas[evento["_momento"].strftime("%d/%m %Hh")] += 1
+
+    primeiro = min(e["_momento"] for e in eventos)
+    ultimo = max(e["_momento"] for e in eventos)
+
+    print("=" * 60)
+    print(f"RELATÓRIO DE ACESSO — {argumentos.log.name}")
+    print("=" * 60)
+    print(f"Janela      : {primeiro:%d/%m/%Y %H:%M} a {ultimo:%d/%m/%Y %H:%M} (UTC)")
+    print(f"Requisições : {len(eventos)} no total")
+    print(f"              {requisicoes_humanas} após excluir robôs e arquivos estáticos")
+    print(f"Faixas de IP: {len(faixas)} distintas (rede /24, não pessoas)")
+    if sessoes_mcp:
+        print(f"Sessões MCP : {len(sessoes_mcp)} distintas")
+
+    erros = sum(quantidade for codigo, quantidade in status.items() if codigo >= 400)
+    if erros:
+        print(f"Erros (4xx/5xx): {erros} ({erros / len(eventos):.1%} das requisições)")
+
+    total = requisicoes_humanas or None
+    imprimir_secao("CLIENTES", clientes, total=len(eventos))
+    imprimir_secao("PÁGINAS MAIS PEDIDAS", paginas, total=total)
+
+    # Origem geográfica: conta faixas de rede, não requisições — uma faixa que pediu
+    # 40 páginas continua sendo um ponto de origem, e contar acessos distorceria o mapa.
+    geo = abrir_indice_geo(Path(argumentos.geo))
+    if geo and faixas:
+        paises, estados = Counter(), Counter()
+        nao_localizadas = 0
+        for faixa in faixas:
+            local = geo.localizar(faixa)
+            if local is None:
+                nao_localizadas += 1
+                continue
+            pais, estado = local
+            paises[pais] += 1
+            estados[f"{pais} · {estado or '(estado não informado)'}"] += 1
+
+        if paises:
+            imprimir_secao("PAÍS (por faixa de rede)", paises, total=sum(paises.values()))
+            imprimir_secao("ESTADO / REGIÃO", estados, total=sum(estados.values()))
+            if nao_localizadas:
+                print(f"\n  {nao_localizadas} faixa(s) sem correspondência no índice.")
+    elif not geo:
+        print(f"\n(Sem geolocalização: índice ausente em {argumentos.geo} —"
+              " ver construir_indice_geo.py.)")
+
+    imprimir_secao("FAIXAS DE REDE MAIS ATIVAS", faixas, total=total)
+
+    if horas:
+        print("\nPOR HORA (UTC)")
+        print("-" * 14)
+        for chave in sorted(horas):
+            print(f"  {horas[chave]:6}  {chave}  {'█' * min(horas[chave], 40)}")
+
+    print("\nO IP chega mascarado do Caddy: conta-se a faixa de rede, não a máquina.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ferramentas/manutencao/relatorio_acesso.py
+++ b/ferramentas/manutencao/relatorio_acesso.py
@@ -239,6 +239,82 @@ def imprimir_secao(titulo: str, contagem: Counter, limite: int = 10, total: int 
         print(f"  ... e mais {restantes} não listados")
 
 
+def formatar_bytes(total: float) -> str:
+    for unidade in ("B", "KiB", "MiB", "GiB"):
+        if abs(total) < 1024 or unidade == "GiB":
+            return f"{total:.0f} {unidade}" if unidade == "B" else f"{total:.1f} {unidade}"
+        total /= 1024
+    return f"{total:.1f} GiB"
+
+
+def relatorio_de_consumo(usos: list[dict]) -> None:
+    """Quem consumiu quanto — a visão de administração do serviço.
+
+    Separa consumo atribuível a uma pessoa do consumo de origem compartilhada. Um IP do
+    claude.ai agrega usuários sem relação entre si: somar aquilo como se fosse um usuário
+    produziria um "heavy user" que não existe.
+    """
+    atores: dict[str, dict] = {}
+    for uso in usos:
+        chave = uso.get("ator")
+        if not chave:
+            continue
+        registro = atores.setdefault(
+            chave,
+            {"chamadas": 0, "bytes": 0, "ms": 0.0, "cliente": uso.get("cliente", "?"),
+             "pessoa": bool(uso.get("pessoa")), "tools": Counter()},
+        )
+        registro["chamadas"] += 1
+        registro["bytes"] += uso.get("bytes", 0) or 0
+        registro["ms"] += uso.get("ms", 0) or 0
+        registro["tools"][uso.get("tool", "?")] += 1
+
+    if not atores:
+        print("\n(Sem identificação de ator nos registros — telemetria anterior à v2.)")
+        return
+
+    print("\nCONSUMO POR ATOR")
+    print("-" * 16)
+    print("  {:<34} {:>8} {:>10} {:>9}".format("ator", "chamadas", "resposta", "tempo"))
+
+    ordenados = sorted(atores.items(), key=lambda item: -item[1]["chamadas"])
+    total_chamadas = sum(r["chamadas"] for _, r in ordenados)
+
+    for chave, registro in ordenados[:15]:
+        # O identificador da OpenAI é longo; o começo já basta para distinguir e agir.
+        rotulo = chave if len(chave) <= 32 else f"{chave[:29]}…"
+        marca = "" if registro["pessoa"] else "  (origem compartilhada)"
+        print(
+            f"  {rotulo:<34} {registro['chamadas']:>8} "
+            f"{formatar_bytes(registro['bytes']):>10} "
+            f"{registro['ms'] / 1000:>8.1f}s{marca}"
+        )
+
+    if len(ordenados) > 15:
+        print(f"  ... e mais {len(ordenados) - 15} atores")
+
+    # Heavy user: quem sozinho responde por fatia desproporcional do total.
+    pessoas = [(k, r) for k, r in ordenados if r["pessoa"]]
+    if pessoas and total_chamadas:
+        maior_chave, maior = pessoas[0]
+        fatia = maior["chamadas"] / total_chamadas
+        print(f"\n  Atores distintos      : {len(atores)}  "
+              f"({len(pessoas)} identificam pessoa)")
+        print(f"  Maior consumidor      : {maior['chamadas']} chamadas "
+              f"({fatia:.0%} do total), {formatar_bytes(maior['bytes'])}")
+        print(f"                          {maior_chave[:56]}")
+        print(f"                          preferidas: "
+              f"{', '.join(t for t, _ in maior['tools'].most_common(3))}")
+        if fatia > 0.5:
+            print("  ⚠ Um único ator responde por mais da metade das chamadas.")
+
+    compartilhado = sum(r["chamadas"] for _, r in ordenados if not r["pessoa"])
+    if compartilhado:
+        print(f"\n  {compartilhado} chamada(s) vieram de origem compartilhada (claude.ai):")
+        print("  o protocolo não expõe o usuário final, então esse consumo é atribuível")
+        print("  à origem, não a uma pessoa.")
+
+
 def relatorio_de_ferramentas(usos: list[dict]) -> None:
     """Mostra quais ferramentas do acervo foram chamadas e quantas acharam algo."""
     chamadas = Counter()
@@ -329,6 +405,7 @@ def main() -> int:
         print("=" * 60)
         print(f"Janela      : {primeiro:%d/%m/%Y %H:%M} a {ultimo:%d/%m/%Y %H:%M} (UTC)")
         relatorio_de_ferramentas(usos)
+        relatorio_de_consumo(usos)
         return 0
 
     clientes = Counter()

--- a/ferramentas/pesquisa/vade-mecum/src/http.ts
+++ b/ferramentas/pesquisa/vade-mecum/src/http.ts
@@ -21,6 +21,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { buildServer } from "./server.js";
+import { identificarAtor } from "./identidade.js";
 
 const PORT = Number(process.env.PORT ?? 8080);
 const MCP_PATH = process.env.MCP_PATH ?? "/mcp";
@@ -51,11 +52,20 @@ function clientIp(req: IncomingMessage): string {
   return req.socket.remoteAddress ?? "desconhecido";
 }
 
-function excedeuLimite(ip: string): boolean {
+/**
+ * Conta requisições por ATOR, não por IP.
+ *
+ * Por IP, todos os usuários do claude.ai caem no mesmo balde — eles chegam pelo mesmo
+ * endereço da Anthropic. Um único usuário pesado consumia a cota de todos os outros, e
+ * barrá-lo significava barrar todo mundo junto. Quando o cliente identifica o usuário
+ * (hoje só o ChatGPT/Codex, via X-Openai-Subject), o limite passa a valer por pessoa;
+ * nos demais casos a chave continua sendo o IP, como antes.
+ */
+function excedeuLimite(chave: string): boolean {
   const agora = Date.now();
-  const historico = (acessos.get(ip) ?? []).filter((t) => agora - t < JANELA_MS);
+  const historico = (acessos.get(chave) ?? []).filter((t) => agora - t < JANELA_MS);
   historico.push(agora);
-  acessos.set(ip, historico);
+  acessos.set(chave, historico);
   return historico.length > RATE_LIMIT_RPM;
 }
 
@@ -143,7 +153,17 @@ const httpServer = createServer(async (req, res) => {
   }
 
   const ip = clientIp(req);
-  if (excedeuLimite(ip)) {
+  const ator = identificarAtor(req, ip);
+  if (excedeuLimite(ator.chave)) {
+    console.log(
+      JSON.stringify({
+        evento: "limite_excedido",
+        ts: new Date().toISOString(),
+        ator: ator.chave,
+        cliente: ator.cliente,
+        pessoa: ator.identificaPessoa,
+      }),
+    );
     return responderJson(res, 429, erroRpc("Limite de requisições excedido. Tente novamente em instantes."));
   }
 
@@ -175,7 +195,11 @@ const httpServer = createServer(async (req, res) => {
             ultimaAtividade.delete(transport.sessionId);
           }
         };
-        const server = buildServer();
+        const server = buildServer({
+          ator: ator.chave,
+          cliente: ator.cliente,
+          identificaPessoa: ator.identificaPessoa,
+        });
         await server.connect(transport);
         await transport.handleRequest(req, res, corpo);
         return;

--- a/ferramentas/pesquisa/vade-mecum/src/http.ts
+++ b/ferramentas/pesquisa/vade-mecum/src/http.ts
@@ -6,13 +6,14 @@
  * e o reutiliza nas chamadas seguintes. As sessões vivem em memória (single-instance).
  *
  * Acesso aberto — o conteúdo é público e as ferramentas são só de leitura — com rate limit
- * por IP. HTTPS e o /.well-known/openai-apps-challenge ficam a cargo de um reverse proxy
- * HTTPS (ex.: Caddy), configurado fora deste repositório.
+ * por IP. HTTPS e o /.well-known/openai-apps-challenge ficam a cargo do reverse proxy
+ * (Caddy); ver deploy/.
  *
  * Variáveis de ambiente:
- *   PORT            porta HTTP (default 8080)
- *   MCP_PATH        caminho do endpoint MCP (default "/mcp")
- *   RATE_LIMIT_RPM  requisições por minuto por IP (default 60)
+ *   PORT             porta HTTP (default 8080)
+ *   MCP_PATH         caminho do endpoint MCP (default "/mcp")
+ *   RATE_LIMIT_RPM   requisições por minuto por IP (default 60)
+ *   SESSION_TTL_MIN  minutos sem requisição até a sessão ser encerrada (default 30)
  */
 
 import { randomUUID } from "node:crypto";
@@ -25,9 +26,20 @@ const PORT = Number(process.env.PORT ?? 8080);
 const MCP_PATH = process.env.MCP_PATH ?? "/mcp";
 const RATE_LIMIT_RPM = Number(process.env.RATE_LIMIT_RPM ?? 60);
 const JANELA_MS = 60_000;
+const SESSAO_OCIOSA_MIN = Number(process.env.SESSION_TTL_MIN ?? 30);
+const SESSAO_OCIOSA_MS = SESSAO_OCIOSA_MIN * 60_000;
 
 // Sessões vivas: mcp-session-id → transporte.
 const transportes = new Map<string, StreamableHTTPServerTransport>();
+
+// Instante da última requisição de cada sessão.
+//
+// Sem isto a sessão só saía do mapa quando o cliente encerrava (DELETE) ou o stream
+// fechava — e na prática os clientes simplesmente somem: em um dia inteiro de tráfego
+// real não houve um único DELETE. Cada sessão abandonada custa ~128 KB que nunca
+// voltavam, o que numa VM de 1 GB, com a base jurídica já ocupando ~550 MB, encurta o
+// tempo até a máquina entrar em swap.
+const ultimaAtividade = new Map<string, number>();
 
 // ── Rate limit por IP (janela deslizante em memória) ─────────────────────────
 
@@ -47,13 +59,43 @@ function excedeuLimite(ip: string): boolean {
   return historico.length > RATE_LIMIT_RPM;
 }
 
-// Limpeza periódica para não vazar memória com IPs inativos.
+// ── Encerramento de sessões ociosas ──────────────────────────────────────────
+
+/** Fecha e esquece as sessões sem requisição há mais de SESSAO_OCIOSA_MS. */
+function encerrarSessoesOciosas(agora: number): number {
+  let encerradas = 0;
+  for (const [sid, visto] of ultimaAtividade) {
+    if (agora - visto < SESSAO_OCIOSA_MS) continue;
+    const transporte = transportes.get(sid);
+    ultimaAtividade.delete(sid);
+    transportes.delete(sid);
+    encerradas++;
+    // O close() dispara onclose, que já remove do mapa — apagar antes evita
+    // depender dessa ordem, e o erro é engolido porque a sessão vai embora de todo jeito.
+    void Promise.resolve(transporte?.close()).catch(() => {});
+  }
+  return encerradas;
+}
+
+// Limpeza periódica: IPs inativos do rate limit e sessões abandonadas.
 const limpeza = setInterval(() => {
   const agora = Date.now();
   for (const [ip, historico] of acessos) {
     const vivos = historico.filter((t) => agora - t < JANELA_MS);
     if (vivos.length === 0) acessos.delete(ip);
     else acessos.set(ip, vivos);
+  }
+
+  const encerradas = encerrarSessoesOciosas(agora);
+  if (encerradas > 0) {
+    console.log(
+      JSON.stringify({
+        evento: "sessoes_encerradas",
+        ts: new Date().toISOString(),
+        quantidade: encerradas,
+        vivas: transportes.size,
+      }),
+    );
   }
 }, JANELA_MS);
 limpeza.unref?.();
@@ -110,6 +152,7 @@ const httpServer = createServer(async (req, res) => {
   try {
     // Sessão existente: GET (stream SSE), POST (requisições) ou DELETE (encerrar).
     if (sessionId && transportes.has(sessionId)) {
+      ultimaAtividade.set(sessionId, Date.now());
       const corpo = req.method === "POST" ? await lerCorpo(req) : undefined;
       await transportes.get(sessionId)!.handleRequest(req, res, corpo);
       return;
@@ -123,10 +166,14 @@ const httpServer = createServer(async (req, res) => {
           sessionIdGenerator: () => randomUUID(),
           onsessioninitialized: (sid) => {
             transportes.set(sid, transport);
+            ultimaAtividade.set(sid, Date.now());
           },
         });
         transport.onclose = () => {
-          if (transport.sessionId) transportes.delete(transport.sessionId);
+          if (transport.sessionId) {
+            transportes.delete(transport.sessionId);
+            ultimaAtividade.delete(transport.sessionId);
+          }
         };
         const server = buildServer();
         await server.connect(transport);

--- a/ferramentas/pesquisa/vade-mecum/src/identidade.test.ts
+++ b/ferramentas/pesquisa/vade-mecum/src/identidade.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import type { IncomingMessage } from "node:http";
+
+import { familiaDoCliente, identificarAtor } from "./identidade.js";
+
+/** Requisição mínima: só os headers importam para a identificação. */
+function req(headers: Record<string, string>): IncomingMessage {
+  return { headers } as unknown as IncomingMessage;
+}
+
+test("usuário do ChatGPT/Codex é identificado pelo subject, não pelo IP", () => {
+  const ator = identificarAtor(
+    req({ "user-agent": "openai-mcp/1.0.0 (Codex)", "x-openai-subject": "v1/ABC" }),
+    "203.0.113.7",
+  );
+  expect(ator.chave).toBe("openai:v1/ABC");
+  expect(ator.origem).toBe("openai-subject");
+  expect(ator.cliente).toBe("Codex");
+  expect(ator.identificaPessoa).toBe(true);
+});
+
+test("mesmo IP com subjects diferentes gera atores diferentes", () => {
+  const cabecalho = { "user-agent": "openai-mcp/1.0.0" };
+  const a = identificarAtor(req({ ...cabecalho, "x-openai-subject": "v1/AAA" }), "203.0.113.7");
+  const b = identificarAtor(req({ ...cabecalho, "x-openai-subject": "v1/BBB" }), "203.0.113.7");
+  expect(a.chave).not.toBe(b.chave);
+});
+
+test("mesmo subject em IPs diferentes continua sendo o mesmo ator", () => {
+  const cabecalho = { "user-agent": "openai-mcp/1.0.0", "x-openai-subject": "v1/AAA" };
+  expect(identificarAtor(req(cabecalho), "203.0.113.7").chave).toBe(
+    identificarAtor(req(cabecalho), "198.51.100.2").chave,
+  );
+});
+
+test("claude.ai cai para IP e é marcado como origem compartilhada", () => {
+  // Todos os usuários do claude.ai chegam pelo IP da Anthropic: somar esse consumo
+  // como se fosse de uma pessoa inventaria um heavy user que não existe.
+  const ator = identificarAtor(req({ "user-agent": "Claude-User" }), "160.79.106.10");
+  expect(ator.chave).toBe("ip:160.79.106.10");
+  expect(ator.origem).toBe("ip");
+  expect(ator.identificaPessoa).toBe(false);
+});
+
+test("Claude Code cai para IP, mas o IP é da pessoa", () => {
+  const ator = identificarAtor(req({ "user-agent": "claude-code/2.1.216 (cli)" }), "191.177.143.9");
+  expect(ator.chave).toBe("ip:191.177.143.9");
+  expect(ator.identificaPessoa).toBe(true);
+});
+
+test("subject vazio não vira ator identificado", () => {
+  const ator = identificarAtor(
+    req({ "user-agent": "openai-mcp/1.0.0", "x-openai-subject": "" }),
+    "203.0.113.7",
+  );
+  expect(ator.chave).toBe("ip:203.0.113.7");
+  expect(ator.origem).toBe("ip");
+});
+
+test("famílias de cliente reconhecidas", () => {
+  expect(familiaDoCliente("openai-mcp/1.0.0 (Codex)")).toBe("Codex");
+  expect(familiaDoCliente("openai-mcp/1.0.0")).toBe("ChatGPT");
+  expect(familiaDoCliente("Claude-User")).toBe("claude.ai");
+  expect(familiaDoCliente("claude-code/2.1.216 (cli)")).toBe("Claude Code");
+  expect(familiaDoCliente("")).toBe("(sem identificação)");
+  expect(familiaDoCliente("Mozilla/5.0")).toBe("outro");
+});

--- a/ferramentas/pesquisa/vade-mecum/src/identidade.ts
+++ b/ferramentas/pesquisa/vade-mecum/src/identidade.ts
@@ -1,0 +1,79 @@
+/**
+ * Identidade do ator por trás de uma chamada — para administrar consumo.
+ *
+ * O serviço é aberto e sem cadastro, então "quem está usando" só pode ser respondido
+ * com o que o cliente manda. O que existe hoje, por cliente:
+ *
+ *   ChatGPT/Codex  X-Openai-Subject — identificador de usuário, ESTÁVEL entre sessões.
+ *                  É o único caso em que dá para dizer "esta pessoa consumiu tanto".
+ *   claude.ai      nada. As requisições saem da infraestrutura da Anthropic, e não há
+ *                  header de usuário: todos os usuários chegam pelo mesmo IP. Aqui a
+ *                  granularidade máxima é a sessão MCP, que morre a cada conversa.
+ *   Claude Code    nada, mas a chamada sai da máquina da pessoa, então o IP serve.
+ *
+ * Consequência prática, que não dá para contornar do lado do servidor: um consumo
+ * excessivo vindo do claude.ai é atribuível a uma sessão, nunca a uma pessoa.
+ *
+ * O identificador da OpenAI é guardado como veio, sem hash. Ele é opaco (não tem nome
+ * nem e-mail) e existe um uso administrativo concreto para o valor original: em caso de
+ * abuso, é o que permite pedir providência a quem sabe de quem se trata. Por isso ele
+ * vive só aqui, na telemetria de uso — no log de acesso do Caddy continua mascarado.
+ */
+
+import type { IncomingMessage } from "node:http";
+
+export interface Ator {
+  /** Chave de agrupamento e de rate limit. Ex.: "openai:v1/FGIA…" ou "ip:203.0.113.7". */
+  readonly chave: string;
+  /** De onde veio a identidade, para o relatório saber o que a chave vale. */
+  readonly origem: "openai-subject" | "ip";
+  /** Família do cliente, para leitura humana. */
+  readonly cliente: string;
+  /** true quando a chave identifica uma pessoa; false quando identifica só uma origem de rede. */
+  readonly identificaPessoa: boolean;
+}
+
+function primeiro(valor: string | string[] | undefined): string | undefined {
+  if (Array.isArray(valor)) return valor[0];
+  return valor;
+}
+
+/** Classifica o cliente pela assinatura do User-Agent. */
+export function familiaDoCliente(userAgent: string): string {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes("openai-mcp")) return ua.includes("codex") ? "Codex" : "ChatGPT";
+  if (ua.includes("claude-user")) return "claude.ai";
+  if (ua.includes("claude-code")) return "Claude Code";
+  if (ua === "") return "(sem identificação)";
+  return "outro";
+}
+
+/**
+ * Deriva o ator de uma requisição.
+ *
+ * `ipDoCliente` é injetado porque quem sabe ler X-Forwarded-For com segurança é o
+ * servidor HTTP, não este módulo.
+ */
+export function identificarAtor(req: IncomingMessage, ipDoCliente: string): Ator {
+  const userAgent = primeiro(req.headers["user-agent"]) ?? "";
+  const cliente = familiaDoCliente(userAgent);
+
+  const subject = primeiro(req.headers["x-openai-subject"]);
+  if (subject && subject.length > 0) {
+    return {
+      chave: `openai:${subject}`,
+      origem: "openai-subject",
+      cliente,
+      identificaPessoa: true,
+    };
+  }
+
+  return {
+    chave: `ip:${ipDoCliente}`,
+    origem: "ip",
+    cliente,
+    // O IP só vale como pessoa quando a chamada sai da máquina dela. Vindo de claude.ai,
+    // é o IP da Anthropic e agrupa usuários que não têm relação entre si.
+    identificaPessoa: cliente !== "claude.ai",
+  };
+}

--- a/ferramentas/pesquisa/vade-mecum/src/mcp.test.ts
+++ b/ferramentas/pesquisa/vade-mecum/src/mcp.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 
 import { CODIGOS_DISPONIVEIS } from "./search/legislacao.js";
+import { normalizarTribunal } from "./search/sumulas.js";
 
 interface ToolMCP {
   name: string;
@@ -17,6 +18,8 @@ interface RespostaMCP {
   result?: {
     tools?: ToolMCP[];
     serverInfo?: { name?: string; version?: string };
+    content?: Array<{ type: string; text?: string }>;
+    isError?: boolean;
   };
 }
 
@@ -101,4 +104,79 @@ test("MCP anuncia cobertura e contagens derivadas dos dados", async () => {
   expect(descricoes).not.toContain("fontes primárias");
   expect(descricoes).not.toContain("Força: ORIENTATIVA");
   expect(descricoes).not.toContain("força persuasiva");
+});
+
+test("filtro de tribunal aceita qualquer caixa e recusa valor desconhecido", () => {
+  expect(normalizarTribunal("stj")).toBe("STJ");
+  expect(normalizarTribunal("STJ")).toBe("STJ");
+  expect(normalizarTribunal(" Stj ")).toBe("STJ");
+  expect(normalizarTribunal("stf")).toBe("STF");
+  expect(normalizarTribunal("VINCULANTE")).toBe("vinculante");
+  expect(normalizarTribunal("todos")).toBe("todos");
+  expect(normalizarTribunal("")).toBe("todos");
+  // Valor irreconhecível precisa virar erro explícito, não busca em tudo.
+  expect(normalizarTribunal("tjpr")).toBeNull();
+  expect(normalizarTribunal("supremo")).toBeNull();
+});
+
+test("buscar_sumula com tribunal em minúsculas devolve o mesmo que em maiúsculas", async () => {
+  const raizMotor = new URL("..", import.meta.url).pathname;
+  const processo = Bun.spawn(["bun", "run", "src/index.ts"], {
+    cwd: raizMotor,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const chamada = (id: number, tribunal: string) => ({
+    jsonrpc: "2.0",
+    id,
+    method: "tools/call",
+    params: { name: "buscar_sumula", arguments: { query: "dano moral", tribunal, limit: 1 } },
+  });
+
+  const mensagens = [
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "teste", version: "1.0" },
+      },
+    },
+    { jsonrpc: "2.0", method: "notifications/initialized" },
+    chamada(2, "STJ"),
+    chamada(3, "stj"),
+    chamada(4, "tjpr"),
+  ];
+
+  processo.stdin.write(mensagens.map((item) => JSON.stringify(item)).join("\n"));
+  processo.stdin.write("\n");
+  processo.stdin.end();
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(processo.stdout).text(),
+    new Response(processo.stderr).text(),
+    processo.exited,
+  ]);
+  expect(exitCode, stderr).toBe(0);
+
+  const respostas = stdout
+    .trim()
+    .split("\n")
+    .map((linha) => JSON.parse(linha) as RespostaMCP);
+  const texto = (id: number) => respostas.find((r) => r.id === id)?.result?.content?.[0]?.text ?? "";
+
+  expect(texto(2)).toContain("SÚMULA STJ");
+  expect(texto(3)).toBe(texto(2));
+  expect(texto(3)).not.toContain("Nenhuma súmula");
+
+  // Tribunal inexistente avisa, em vez de devolver busca vazia como se nada existisse.
+  expect(texto(4)).toContain("Tribunal indisponível");
+  expect(respostas.find((r) => r.id === 4)?.result?.isError).toBe(true);
+
+  // A telemetria vai para stderr; o stdout do stdio é só protocolo.
+  expect(stderr).toContain("uso_ferramenta");
 });

--- a/ferramentas/pesquisa/vade-mecum/src/search/sumulas.ts
+++ b/ferramentas/pesquisa/vade-mecum/src/search/sumulas.ts
@@ -47,6 +47,28 @@ export interface SumulaVinculante {
 
 export type Tribunal = "STJ" | "STF" | "vinculante";
 
+/** Valores aceitos no filtro de tribunal, para mensagens de erro e documentação. */
+export const TRIBUNAIS_DISPONIVEIS = ["STJ", "STF", "vinculante"] as const;
+
+/**
+ * Interpreta o filtro de tribunal recebido de fora.
+ *
+ * `buscarSumulas` compara o tribunal por igualdade estrita, então "stj" em minúsculas
+ * devolvia lista vazia — indistinguível de "não existe súmula sobre isso". Quem chama
+ * o MCP é um modelo, que escreve o filtro como bem entende; aqui a caixa é normalizada
+ * e o valor irreconhecível vira erro explícito, nunca silêncio.
+ *
+ * Devolve `null` quando o valor não corresponde a nenhum tribunal conhecido.
+ */
+export function normalizarTribunal(valor: string): Tribunal | "todos" | null {
+  const limpo = valor.trim().toLowerCase();
+  if (limpo === "" || limpo === "todos") return "todos";
+  if (limpo === "stj") return "STJ";
+  if (limpo === "stf") return "STF";
+  if (limpo === "vinculante" || limpo === "vinculantes") return "vinculante";
+  return null;
+}
+
 // ── Data loading ───────────────────────────────────────────────────────────
 
 const stj = require("../../data/sumulas_stj.json") as {

--- a/ferramentas/pesquisa/vade-mecum/src/server.ts
+++ b/ferramentas/pesquisa/vade-mecum/src/server.ts
@@ -8,13 +8,19 @@
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolRequest,
+  type CallToolResult,
+} from "@modelcontextprotocol/sdk/types.js";
 
 import {
   buscarSumulas,
   formatSumula,
+  normalizarTribunal,
   TOTAIS_SUMULAS,
-  type Tribunal,
+  TRIBUNAIS_DISPONIVEIS,
 } from "./search/sumulas.js";
 import {
   buscarTeses,
@@ -62,6 +68,42 @@ const ANOTACOES_LEITURA = {
   idempotentHint: true,
   openWorldHint: false,
 } as const;
+
+// ── Telemetria de uso ────────────────────────────────────────────────────────
+//
+// Registra QUAL ferramenta foi chamada, se houve resultado e quanto demorou. Serve
+// para saber que partes do acervo são realmente usadas e onde a busca falha.
+//
+// O termo pesquisado NUNCA é registrado: a consulta de um advogado revela a matéria
+// e, muitas vezes, o caso — isso é sigilo (ver SIGILO-E-DADOS.md). Só saem daqui
+// categorias fixas do próprio catálogo (tribunal, código) e medidas.
+//
+// A linha vai para a saída de ERRO, não a padrão: no transporte stdio a saída padrão
+// é o canal do protocolo MCP, e escrever nela corromperia as mensagens. O journald
+// recolhe as duas:  journalctl -u vade-mecum-mcp | grep uso_ferramenta
+const SEM_RESULTADO = /^Nenhum[ao]?\s/;
+
+function registrarUso(
+  request: CallToolRequest,
+  medida: { ms: number; achou?: boolean; falhou: boolean },
+): void {
+  const args = request.params.arguments ?? {};
+  const facetaTexto = (valor: unknown): string | undefined =>
+    typeof valor === "string" && valor.length > 0 ? valor : undefined;
+
+  console.error(
+    JSON.stringify({
+      evento: "uso_ferramenta",
+      ts: new Date().toISOString(),
+      tool: request.params.name,
+      tribunal: facetaTexto(args.tribunal),
+      codigo: facetaTexto(args.codigo),
+      achou: medida.achou,
+      falhou: medida.falhou || undefined,
+      ms: medida.ms,
+    }),
+  );
+}
 
 export function buildServer(): Server {
   const server = new Server(
@@ -286,13 +328,27 @@ Use para verificar o texto exato de um dispositivo legal antes de citar.`,
     };
   });
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const despacharTool = async (request: CallToolRequest): Promise<CallToolResult> => {
     const { name, arguments: args } = request.params;
 
     if (name === "buscar_sumula") {
       const query = String(args?.query ?? "");
-      const tribunal = (args?.tribunal ?? "todos") as Tribunal | "todos";
+      const tribunalInformado = String(args?.tribunal ?? "todos");
+      const tribunal = normalizarTribunal(tribunalInformado);
       const limit = Number(args?.limit ?? 5);
+
+      if (!tribunal) {
+        const disponiveis = [...TRIBUNAIS_DISPONIVEIS, "todos"].join(", ");
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Tribunal indisponível: "${tribunalInformado}". Use: ${disponiveis}.`,
+            },
+          ],
+          isError: true,
+        };
+      }
 
       const results = buscarSumulas(query, tribunal, limit);
       if (results.length === 0) {
@@ -390,6 +446,34 @@ Use para verificar o texto exato de um dispositivo legal antes de citar.`,
     }
 
     return { content: [{ type: "text", text: `Tool desconhecida: ${name}` }] };
+  };
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const inicio = performance.now();
+    let achou: boolean | undefined;
+    let falhou = false;
+    try {
+      const resposta = await despacharTool(request);
+      falhou = resposta.isError === true;
+      // Busca sem acerto responde com "Nenhuma súmula encontrada…" e afins — é o
+      // sinal de que a pergunta não achou nada, e é o que mais interessa medir.
+      // Chamada malformada não conta como busca: não houve pesquisa para achar algo.
+      if (!falhou) {
+        const primeiro = resposta.content?.[0];
+        const texto = primeiro?.type === "text" ? primeiro.text : "";
+        achou = !SEM_RESULTADO.test(texto);
+      }
+      return resposta;
+    } catch (erro) {
+      falhou = true;
+      throw erro;
+    } finally {
+      registrarUso(request, {
+        ms: Math.round((performance.now() - inicio) * 10) / 10,
+        achou,
+        falhou,
+      });
+    }
   });
 
   return server;

--- a/ferramentas/pesquisa/vade-mecum/src/server.ts
+++ b/ferramentas/pesquisa/vade-mecum/src/server.ts
@@ -83,9 +83,20 @@ const ANOTACOES_LEITURA = {
 // recolhe as duas:  journalctl -u vade-mecum-mcp | grep uso_ferramenta
 const SEM_RESULTADO = /^Nenhum[ao]?\s/;
 
+/**
+ * Quem está do outro lado da sessão. Preenchido pelo entrypoint HTTP; no uso local
+ * (stdio) não existe ator remoto e o campo fica ausente.
+ */
+export interface ContextoDeUso {
+  readonly ator: string;
+  readonly cliente: string;
+  readonly identificaPessoa: boolean;
+}
+
 function registrarUso(
   request: CallToolRequest,
-  medida: { ms: number; achou?: boolean; falhou: boolean },
+  medida: { ms: number; bytes: number; achou?: boolean; falhou: boolean },
+  contexto?: ContextoDeUso,
 ): void {
   const args = request.params.arguments ?? {};
   const facetaTexto = (valor: unknown): string | undefined =>
@@ -96,16 +107,22 @@ function registrarUso(
       evento: "uso_ferramenta",
       ts: new Date().toISOString(),
       tool: request.params.name,
+      ator: contexto?.ator,
+      cliente: contexto?.cliente,
+      // Distingue "consumo de uma pessoa" de "consumo de uma origem compartilhada":
+      // sem isso, o relatório somaria usuários distintos do claude.ai como se fossem um.
+      pessoa: contexto ? contexto.identificaPessoa : undefined,
       tribunal: facetaTexto(args.tribunal),
       codigo: facetaTexto(args.codigo),
       achou: medida.achou,
       falhou: medida.falhou || undefined,
       ms: medida.ms,
+      bytes: medida.bytes,
     }),
   );
 }
 
-export function buildServer(): Server {
+export function buildServer(contexto?: ContextoDeUso): Server {
   const server = new Server(
     { name: "vade-mecum", version: "1.0.0" },
     { capabilities: { tools: {} } }
@@ -452,15 +469,18 @@ Use para verificar o texto exato de um dispositivo legal antes de citar.`,
     const inicio = performance.now();
     let achou: boolean | undefined;
     let falhou = false;
+    let bytes = 0;
     try {
       const resposta = await despacharTool(request);
       falhou = resposta.isError === true;
+      const primeiro = resposta.content?.[0];
+      const texto = primeiro?.type === "text" ? primeiro.text : "";
+      // Peso da resposta: é o que o consumo de banda realmente mede.
+      bytes = Buffer.byteLength(texto, "utf8");
       // Busca sem acerto responde com "Nenhuma súmula encontrada…" e afins — é o
       // sinal de que a pergunta não achou nada, e é o que mais interessa medir.
       // Chamada malformada não conta como busca: não houve pesquisa para achar algo.
       if (!falhou) {
-        const primeiro = resposta.content?.[0];
-        const texto = primeiro?.type === "text" ? primeiro.text : "";
         achou = !SEM_RESULTADO.test(texto);
       }
       return resposta;
@@ -468,11 +488,11 @@ Use para verificar o texto exato de um dispositivo legal antes de citar.`,
       falhou = true;
       throw erro;
     } finally {
-      registrarUso(request, {
-        ms: Math.round((performance.now() - inicio) * 10) / 10,
-        achou,
-        falhou,
-      });
+      registrarUso(
+        request,
+        { ms: Math.round((performance.now() - inicio) * 10) / 10, bytes, achou, falhou },
+        contexto,
+      );
     }
   });
 


### PR DESCRIPTION
Leva para a main a telemetria que hoje roda **apenas como código não-commitado na VM** (capturada em `vm/estado-producao-2026-07-22`). Traz o motor à paridade com o que está em produção e desbloqueia a VM seguir a `main`.

## O que entra
- **`identidade.ts`** — identifica o ator por trás de cada chamada para administrar consumo (serviço aberto, sem cadastro).
- **`http.ts` / `server.ts` / `sumulas.ts`** — medição de uso do MCP e do site, limite por usuário, e correções que a medição revelou.
- **`relatorio_acesso.py`** — relatório de uso (logs do Caddy e journald).
- **`construir_indice_geo.py`** — índice geográfico.
- Testes: `identidade.test.ts`, `mcp.test.ts`.

## Verificação
- Motor (bun): typecheck limpo, 34 testes verdes (inclui os de telemetria).
- Manutenção (python): 85 testes verdes; snapshots coerentes.

## Contexto
Sem overlap com o que já está na `main` (o fix do monitor e a atualização dos temas mexem em `manutencao/` e `data/`; esta feature mexe em `src/`). Depois do merge, a VM pode passar a seguir a `main` (telemetria + temas + fix num só lugar) e o deploy automático (timer) passa a funcionar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)