### PR TITLE
chore(base): atualiza situação de 5 temas do STJ e do STF

### DIFF
--- a/base-juridica/snapshots.json
+++ b/base-juridica/snapshots.json
@@ -30,20 +30,22 @@
       }
     },
     "flash_temas_stj.json": {
-      "versao": 3,
-      "sha256": "468ab45545661a2722440f0f76315dd23316550b64360f5dbf17ecf5cd079695",
-      "gerado_em": "2026-07-22T23:39:48+00:00",
+      "versao": 4,
+      "sha256": "77c59e71e330b5c6f92182d0a99c38bfe7841a29ee120b8e5988cfb0a2e75589",
+      "gerado_em": "2026-07-29T19:41:49+00:00",
       "registros": 1462,
       "colecao": "temas",
       "mudancas": {
         "adicionados": 0,
         "removidos": 0,
-        "alterados": 2,
+        "alterados": 4,
         "amostra_adicionados": [],
         "amostra_removidos": [],
         "amostra_alterados": [
-          "1357",
-          "948"
+          "1147",
+          "1175",
+          "1210",
+          "1304"
         ]
       }
     },
@@ -4673,9 +4675,9 @@
       }
     },
     "temas_rg_stf.json": {
-      "versao": 2,
-      "sha256": "e62365da2996302d242d5d5a12ea7ef31722173755d7f0104c035226a493d646",
-      "gerado_em": "2026-07-23T01:23:10+00:00",
+      "versao": 3,
+      "sha256": "93bbcfc4606f8a77950e9f6d02d95e27e00622b9abe60af0b0e098201437b16c",
+      "gerado_em": "2026-07-29T19:41:49+00:00",
       "registros": 1470,
       "colecao": "temas",
       "mudancas": {
@@ -4685,7 +4687,7 @@
         "amostra_adicionados": [],
         "amostra_removidos": [],
         "amostra_alterados": [
-          "1468"
+          "1456"
         ]
       }
     }

--- a/ferramentas/pesquisa/vade-mecum/data/flash_temas_stj.json
+++ b/ferramentas/pesquisa/vade-mecum/data/flash_temas_stj.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "version": "2.0",
-    "generatedAt": "2026-07-22T23:39:48+00:00",
+    "generatedAt": "2026-07-29T19:41:49+00:00",
     "totalTemas": 1462,
     "source": {
       "provenanceStatus": "reproducible_pipeline",
@@ -22,8 +22,8 @@
         }
       },
       "method": "Junção determinística de Temas.csv e Processos.csv por sequencialPrecedente; seleção preferencial do leading case.",
-      "metadata_sha256": "e77aff121bcb043e46cabafb84bd55fac6f8571967977ebab1018ee9b0e47df4",
-      "collectedAt": "2026-07-22T23:39:48+00:00"
+      "metadata_sha256": "ebb4ebfa0235f8f9001cd5a9295a56dd85ee21b835b645e7e0b8c4493e932201",
+      "collectedAt": "2026-07-29T19:41:49+00:00"
     },
     "transformacao": "temas_stj_csv_v1"
   },
@@ -32984,7 +32984,7 @@
     },
     "1147": {
       "numero": 1147,
-      "situacao": "Acórdão Publicado - RE Pendente",
+      "situacao": "Trânsito em Julgado",
       "ramo": "Serviços",
       "assuntos": [
         "Serviços",
@@ -33771,7 +33771,7 @@
     },
     "1175": {
       "numero": 1175,
-      "situacao": "Acórdão Publicado - RE Pendente",
+      "situacao": "Trânsito em Julgado",
       "ramo": "Descontos Indevidos",
       "assuntos": [
         "Descontos Indevidos",
@@ -34757,7 +34757,7 @@
     },
     "1210": {
       "numero": 1210,
-      "situacao": "Acórdão Publicado",
+      "situacao": "Trânsito em Julgado",
       "ramo": "DIREITO CIVIL",
       "assuntos": [
         "DIREITO CIVIL",
@@ -37395,7 +37395,7 @@
     },
     "1304": {
       "numero": 1304,
-      "situacao": "Acórdão Publicado - RE Pendente",
+      "situacao": "Acórdão Publicado",
       "ramo": "IPI/ Imposto sobre Produtos Industrializados",
       "assuntos": [
         "IPI/ Imposto sobre Produtos Industrializados"

--- a/ferramentas/pesquisa/vade-mecum/data/temas_rg_stf.json
+++ b/ferramentas/pesquisa/vade-mecum/data/temas_rg_stf.json
@@ -5,14 +5,14 @@
     "tribunal": "STF",
     "totalTemas": 1470,
     "temasComTese": 1300,
-    "generatedAt": "2026-07-23T01:23:10+00:00",
+    "generatedAt": "2026-07-29T19:41:49+00:00",
     "situacoes": {
       "Acórdão de Repercussão Geral publicado": 137,
-      "Acórdão de mérito publicado": 36,
+      "Acórdão de mérito publicado": 37,
       "Analisada Preliminar de Repercussão Geral": 3,
       "Cancelado": 21,
       "Em julgamento": 3,
-      "Mérito julgado": 7,
+      "Mérito julgado": 6,
       "Trânsito em Julgado": 1263
     },
     "descricao": "Temas de Repercussão Geral do STF extraídos da exportação oficial",
@@ -24,7 +24,7 @@
         "temaUrlTemplate": "https://portal.stf.jus.br/jurisprudenciaRepercussao/verTeseTema.asp?numTema={numero}"
       },
       "method": "Tabela HTML (application/vnd.ms-excel) do exportarDados.asp parseada com a biblioteca padrão; mojibake corrigido por célula (cp1252→utf-8).",
-      "collectedAt": "2026-07-23T01:23:10+00:00",
+      "collectedAt": "2026-07-29T19:41:49+00:00",
       "limitacoes": "A coluna 'Assuntos' do export duplica 'Descrição', então a taxonomia de assuntos não é fornecida por esta rota. O flag de suspensão nacional (art. 1.035, §5º, CPC) não existe nas rotas estáticas — só na base Qlik do STF."
     },
     "transformacao": "temas_rg_stf_html_v1"
@@ -26683,7 +26683,7 @@
       "titulo": "Prazo prescricional para ações indenizatórias contra a União decorrentes da política de isolamento compulsório de pessoas com hanseníase.",
       "descricao": "Recurso extraordinário em que se discute, à luz dos artigos 1º, III; 5º, V e X; 37, § 6º; e 227, da Constituição Federal, se (i) a pretensão indenizatória da parte autora está sujeita à prescrição quinquenal prevista no Decreto nº 20.910/32; e se (ii) é aplicável ao caso a tese da imprescritibilidade de ações indenizatórias decorrentes de violações a direitos fundamentais.",
       "repercussao": "Há (com reafirmação de jurisprudência)",
-      "situacao": "Mérito julgado",
+      "situacao": "Acórdão de mérito publicado",
       "dataJulgamento": "",
       "tese": "Prescrevem em 5 anos, a contar da publicação da ata de julgamento da ADPF 1.060, as pretensões de indenização propostas contra a União por filhos de pessoas atingidas pela hanseníase cujo fundamento seja o afastamento forçado promovido pelo Estado entre eles e seus pais, sem prejuízo da necessária demonstração, em cada caso, dos pressupostos da responsabilização civil do Estado.",
       "dataTese": "",


### PR DESCRIPTION
Resolve os sinais de mudança apontados pelo monitoramento semanal.

Closes #14
Closes #15

## O que mudou

Nenhuma adição, **nenhuma remoção**, contagens preservadas (1.462 temas repetitivos do STJ e 1.470 temas de repercussão geral do STF). Só o campo `situacao` mudou — nenhuma alteração de tese, questão submetida ou enunciado.

| Tema | Antes | Depois |
|---|---|---|
| STJ 1147 | Acórdão Publicado - RE Pendente | Trânsito em Julgado |
| STJ 1175 | Acórdão Publicado - RE Pendente | Trânsito em Julgado |
| STJ 1210 | Acórdão Publicado | Trânsito em Julgado |
| STJ 1304 | Acórdão Publicado - RE Pendente | Acórdão Publicado |
| STF RG 1456 | Mérito julgado | Acórdão de mérito publicado |

## Fonte

- Portal de Dados Abertos do STJ — pacote CKAN `precedentes-qualificados`, `Temas.csv` e `Processos.csv` (`Last-Modified` 29/07/2026 17:15 GMT);
- exportação oficial do Portal da Repercussão Geral do STF.

Coleta em 29/07/2026 pelo `atualizar_base_juridica.py` (execução `2026-07-29`), URLs oficiais sem redirecionamento externo, registradas no recibo local.

## Justificativa jurídica

São avanços de fase processual dos próprios precedentes, publicados pelas fontes oficiais. O trânsito em julgado dos temas 1147, 1175 e 1210 encerra a pendência recursal registrada no snapshot anterior, e a publicação do acórdão no Tema 1456 do STF torna o julgado citável pela via oficial. Manter a situação antiga induziria a erro sobre a estabilidade do precedente.

## Verificação

- `validacao.json` sem erros nos dois conjuntos;
- nenhum gate acionado (sem remoções; volume muito abaixo do limiar de 25%);
- `snapshots.json` regenerado (`flash_temas_stj` v4, `temas_rg_stf` v3) e `--verificar` coerente em 285 arquivos;
- `auditar_base_juridica.py --strict`: nenhuma inconsistência estrutural;
- `gerar_indices_derivados.py --verificar`: reprodutível;
- 102 testes Python e 58 testes do motor (`bun test`) passando; `bun run typecheck` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
