### PR TITLE
fix(base): corrige duas teses revisadas pelo STJ e cria o registro de conferência

### DIFF
--- a/.github/workflows/monitorar-base.yml
+++ b/.github/workflows/monitorar-base.yml
@@ -6,7 +6,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  # write só por causa do registro de conferência (base-juridica/verificacoes.json).
+  # Nenhum dado jurídico é promovido aqui: o monitor não toca nos JSON publicados.
+  contents: write
   issues: write
 
 jobs:
@@ -41,11 +43,31 @@ jobs:
         env:
           EXCLUIR: sumulas_stj,jurisprudencia_teses_stj,sumulas_stf,sumulas_vinculantes,temas_rg_stf,informativo_stf
         run: |
+          # Uma execução só, gravando os dois formatos: monitorar duas vezes
+          # dobrava as requisições aos portais oficiais sem necessidade.
           python3 ferramentas/manutencao/atualizar_base_juridica.py monitorar \
-            --excluir "$EXCLUIR" > monitoramento.txt
-          python3 ferramentas/manutencao/atualizar_base_juridica.py monitorar \
-            --excluir "$EXCLUIR" --json > monitoramento.json
+            --excluir "$EXCLUIR" --registrar \
+            --json-em monitoramento.json > monitoramento.txt
           cat monitoramento.txt
+
+      # O registro responde "quando isto foi conferido?", que o manifesto de
+      # snapshots não responde (ele guarda a última *mudança*). Sem isto, família
+      # estável desde junho aparece no site como se estivesse abandonada.
+      - name: Registrar a conferência no repositório
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- base-juridica/verificacoes.json; then
+            echo "Registro inalterado — nada a commitar."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add base-juridica/verificacoes.json
+          git commit -q -m "chore(base): registra a conferência semanal das fontes
+
+          Gravado por monitorar-base.yml. Sinal barato (contagem, GET condicional):
+          não detecta alteração de enunciado — essa exige recoleta."
+          git push
 
       - name: Abrir ou atualizar a issue de monitoramento
         env:

--- a/base-juridica/ATUALIZACAO.md
+++ b/base-juridica/ATUALIZACAO.md
@@ -158,6 +158,43 @@ atualiza uma issue quando há sinais de mudança ou erros. Nenhuma etapa
 automatizada promove dados: a preparação, a revisão e a promoção continuam
 seguindo este protocolo.
 
+### Registro de conferência (`verificacoes.json`)
+
+`snapshots.json` responde "quando isto mudou por último?". Falta a outra
+pergunta: **"quando isto foi conferido por último?"**. Sem ela, uma família
+conferida hoje e estável desde junho parece abandonada desde junho — o dado
+está certo, a leitura engana. O registro versionado
+[`verificacoes.json`](verificacoes.json) responde isso, por conjunto:
+
+```bash
+# sinal barato (o que o monitor semanal faz)
+python3 ferramentas/manutencao/atualizar_base_juridica.py monitorar --registrar
+
+# conferência forte, a partir do relatório de diferenças de uma recoleta
+python3 ferramentas/manutencao/atualizar_base_juridica.py comparar \
+  --execucao <execucao> --conjunto todos --registrar
+```
+
+Três decisões que o registro precisa respeitar:
+
+- **`metodo` separa as duas forças.** `sinal` é o monitor barato e **não vê
+  alteração de enunciado**; `recoleta` compara o conteúdo inteiro contra a fonte.
+  `recoletado_em` guarda a última conferência forte e nunca é sobrescrito por um
+  sinal — um sinal de hoje não apaga o fato de que a recoleta foi ontem.
+- **Merge por conjunto, nunca substituição.** O monitor da nuvem pula as seis
+  famílias que exigem rede aceita; elas são conferidas de outro ponto. Reescrever
+  o arquivo inteiro faria a última execução apagar a conferência da outra.
+- **Erro não é conferência.** Se a fonte não respondeu (403, timeout), a data
+  anterior permanece e o erro é registrado à parte, em `ultimo_erro_em`. Afirmar
+  frescor sobre o que ninguém verificou seria o mesmo vício que o projeto combate.
+
+Por que a distinção não é teórica: em **29/07/2026** o sinal barato deu
+"sem mudança" em todas as 288 fontes, e a recoleta completa encontrou **duas teses
+da Jurisprudência em Teses com o enunciado substituído** — uma delas com o sentido
+invertido (`JT_087_T09`, revista sob o rito do art. 1.036 do CPC, Tema 1353) — mais
+51 súmulas do STF sem os precedentes. Quando a pergunta é "está atualizado de
+fato?", a resposta vem da recoleta, não do sinal.
+
 ### Fontes que exigem rede aceita (STF e SCON do STJ)
 
 Os portais do STF e o SCON do STJ recusam requisição vinda de **IP de datacenter**:

--- a/base-juridica/snapshots.json
+++ b/base-juridica/snapshots.json
@@ -58,12 +58,22 @@
       "mudancas": null
     },
     "jt_stj.json": {
-      "versao": 1,
-      "sha256": "c34935f5b3fd9412151db0cf9acc09e4685ef489322adebaa6b31e22fb479dd5",
-      "gerado_em": "2026-07-19",
+      "versao": 2,
+      "sha256": "12cc8b13f6329c3503102b0204085af5056e97c2d2e360d4e968b66c5ead5fdf",
+      "gerado_em": "2026-07-30",
       "registros": 3508,
       "colecao": "teses",
-      "mudancas": null
+      "mudancas": {
+        "adicionados": 0,
+        "removidos": 0,
+        "alterados": 2,
+        "amostra_adicionados": [],
+        "amostra_removidos": [],
+        "amostra_alterados": [
+          "JT_045_T13",
+          "JT_087_T09"
+        ]
+      }
     },
     "lei_adct.json": {
       "versao": 2,
@@ -4633,12 +4643,30 @@
       }
     },
     "sumulas_stf.json": {
-      "versao": 1,
-      "sha256": "e9e84c1296a46929fe2f2eaf4924f79a272ff7c5ab7fc667e297f9b253f5f324",
-      "gerado_em": "2026-07-19",
+      "versao": 2,
+      "sha256": "4d54cf7b46aae8d0f9b6b78df4eec14386b478b54c2df1763f9a9ca0329de648",
+      "gerado_em": "2026-07-30",
       "registros": 736,
       "colecao": "sumulas",
-      "mudancas": null
+      "mudancas": {
+        "adicionados": 0,
+        "removidos": 0,
+        "alterados": 51,
+        "amostra_adicionados": [],
+        "amostra_removidos": [],
+        "amostra_alterados": [
+          "121",
+          "14",
+          "145",
+          "15",
+          "208",
+          "235",
+          "267",
+          "269",
+          "27",
+          "303"
+        ]
+      }
     },
     "sumulas_stj.json": {
       "versao": 1,

--- a/base-juridica/verificacoes.json
+++ b/base-juridica/verificacoes.json
@@ -1,0 +1,216 @@
+{
+  "gerado_em": "2026-07-30T02:10:47+00:00",
+  "significado": "conferido_em é a última verificação da fonte oficial que respondeu; não é a data da última mudança promovida (essa está em snapshots.json). Situação sem_mudanca com conferido_em recente significa fonte estável, não base parada. metodo=sinal é o monitor barato, que não detecta alteração de enunciado; metodo=recoleta compara o conteúdo inteiro contra a fonte, e recoletado_em guarda a última vez que isso foi feito.",
+  "conjuntos": {
+    "espelhos_stj": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "informativo_stf": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "jurisprudencia_teses_stj": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao": {
+      "situacao": "sem_mudanca",
+      "fontes": 19,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_codificadas": {
+      "situacao": "sem_mudanca",
+      "fontes": 7,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_codificadas_ccom": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_consumidor_bancario_l15040": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_decretos": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_educacao_lc220": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_empresarial_d2044": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_esparsas_administrativo": {
+      "situacao": "sem_mudanca",
+      "fontes": 23,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_esparsas_civel_familia": {
+      "situacao": "sem_mudanca",
+      "fontes": 18,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_esparsas_consumidor_bancario": {
+      "situacao": "sem_mudanca",
+      "fontes": 24,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_esparsas_eleitoral": {
+      "situacao": "sem_mudanca",
+      "fontes": 13,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_esparsas_empresarial": {
+      "situacao": "sem_mudanca",
+      "fontes": 28,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_esparsas_imobiliario_agrario": {
+      "situacao": "sem_mudanca",
+      "fontes": 10,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_esparsas_penal": {
+      "situacao": "sem_mudanca",
+      "fontes": 17,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_esparsas_previdenciario": {
+      "situacao": "sem_mudanca",
+      "fontes": 12,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_esparsas_processual_constitucional": {
+      "situacao": "sem_mudanca",
+      "fontes": 19,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_esparsas_regulatorio_outros": {
+      "situacao": "sem_mudanca",
+      "fontes": 19,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_esparsas_trabalhista": {
+      "situacao": "sem_mudanca",
+      "fontes": 27,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_esparsas_tributario": {
+      "situacao": "sem_mudanca",
+      "fontes": 16,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_estatutos": {
+      "situacao": "sem_mudanca",
+      "fontes": 17,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_reforma_tributaria": {
+      "situacao": "sem_mudanca",
+      "fontes": 2,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "legislacao_tributario_lc225": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "sumulas_stf": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "sumulas_stj": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "sumulas_vinculantes": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "temas_repetitivos_stj": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    },
+    "temas_rg_stf": {
+      "situacao": "sem_mudanca",
+      "fontes": 1,
+      "conferido_em": "2026-07-30T02:10:47+00:00",
+      "metodo": "recoleta",
+      "recoletado_em": "2026-07-30T02:10:47+00:00"
+    }
+  }
+}

--- a/ferramentas/manutencao/atualizar_base_juridica.py
+++ b/ferramentas/manutencao/atualizar_base_juridica.py
@@ -38,6 +38,7 @@ sys.setrecursionlimit(50000)
 ROOT = Path(__file__).resolve().parents[2]
 MANIFESTO_PADRAO = ROOT / "base-juridica" / "fontes.json"
 AREA_PADRAO = ROOT / ".atualizacao-base-juridica"
+VERIFICACOES_PADRAO = ROOT / "base-juridica" / "verificacoes.json"
 USER_AGENT = (
     "Mozilla/5.0 (compatible; Advocacia-Aberta/1.0; "
     "+https://github.com/emidio-a11y/advocacia-aberta)"
@@ -2801,6 +2802,114 @@ def monitorar_conjuntos(
     return resultado
 
 
+def situacao_do_conjunto(itens: list[dict[str, Any]]) -> str:
+    """Reduz os sinais das fontes de um conjunto a uma situação única.
+
+    A ordem é deliberada: erro domina (não se afirma conferência sobre o que não
+    respondeu), depois mudança, e só então ausência de mudança.
+    """
+    situacoes = {item["situacao"] for item in itens}
+    for candidata in ("erro", "mudou", "indeterminado"):
+        if candidata in situacoes:
+            return candidata
+    return "sem_mudanca" if situacoes == {"sem_mudanca"} else "indeterminado"
+
+
+def resultado_da_comparacao(relatorio: dict[str, Any]) -> dict[str, Any]:
+    """Converte o relatório de diferenças em resultado de verificação.
+
+    A recoleta é a conferência forte: compara o conteúdo inteiro contra a fonte, e
+    não um sinal indireto. Em 29/07/2026 foi ela que achou duas teses da
+    Jurisprudência em Teses com enunciado substituído (uma com o sentido invertido)
+    e 51 súmulas do STF sem precedentes — tudo que o sinal barato deu como
+    "sem mudança", porque a edição mais recente do índice e as contagens por estado
+    não se moveram.
+    """
+    conjuntos: dict[str, list[dict[str, str]]] = {}
+    for conjunto_id, itens in relatorio["conjuntos"].items():
+        registros = []
+        for item in itens:
+            mudou = bool(
+                item["adicionados"] or item["removidos"] or item["alterados"]
+            )
+            registros.append(
+                {
+                    "alvo": item["arquivo"],
+                    "situacao": "mudou" if mudou else "sem_mudanca",
+                    "detalhe": (
+                        f"+{len(item['adicionados'])} "
+                        f"-{len(item['removidos'])} "
+                        f"~{len(item['alterados'])}"
+                    ),
+                }
+            )
+        conjuntos[conjunto_id] = registros
+    return {"verificado_em": relatorio["gerado_em"], "conjuntos": conjuntos}
+
+
+def registrar_verificacao(
+    resultado: dict[str, Any], caminho: Path, metodo: str = "sinal"
+) -> dict[str, Any]:
+    """Grava em disco quando cada conjunto foi conferido contra a fonte oficial.
+
+    Existe porque o snapshot só registra a última *mudança* promovida. Sem isto,
+    uma família conferida hoje e inalterada desde junho aparece como se estivesse
+    parada em junho — o dado está atualizado, mas a leitura sugere abandono.
+
+    O merge é por conjunto, nunca substituição do arquivo: o monitor da nuvem pula
+    as seis famílias que exigem rede aceita, e essas são conferidas de outro ponto.
+    Se cada execução reescrevesse o registro inteiro, a última a rodar apagaria a
+    conferência da outra.
+
+    Erro de acesso não conta como conferência: preserva-se a data anterior e
+    registra-se o erro à parte, para não afirmar frescor que não houve.
+
+    `metodo` separa as duas forças de conferência, porque elas não valem o mesmo:
+    "sinal" é o monitor barato (contagem, GET condicional, `last_modified`) e não vê
+    alteração de enunciado; "recoleta" compara o conteúdo inteiro contra a fonte.
+    Por isso `recoletado_em` é guardado à parte e nunca é sobrescrito por um sinal:
+    um sinal de hoje não apaga o fato de que a conferência forte foi ontem.
+    """
+    anterior: dict[str, Any] = {}
+    if caminho.exists():
+        anterior = json.loads(caminho.read_text(encoding="utf-8"))
+    conjuntos: dict[str, Any] = dict(anterior.get("conjuntos") or {})
+
+    for conjunto_id, itens in resultado["conjuntos"].items():
+        situacao = situacao_do_conjunto(itens)
+        registro = dict(conjuntos.get(conjunto_id) or {})
+        registro["situacao"] = situacao
+        registro["fontes"] = len(itens)
+        if situacao == "erro":
+            registro["ultimo_erro_em"] = resultado["verificado_em"]
+            registro.setdefault("conferido_em", None)
+        else:
+            registro["conferido_em"] = resultado["verificado_em"]
+            registro["metodo"] = metodo
+            if metodo == "recoleta":
+                registro["recoletado_em"] = resultado["verificado_em"]
+            registro.pop("ultimo_erro_em", None)
+        conjuntos[conjunto_id] = registro
+
+    saida = {
+        "gerado_em": resultado["verificado_em"],
+        "significado": (
+            "conferido_em é a última verificação da fonte oficial que respondeu; "
+            "não é a data da última mudança promovida (essa está em snapshots.json). "
+            "Situação sem_mudanca com conferido_em recente significa fonte estável, "
+            "não base parada. metodo=sinal é o monitor barato, que não detecta "
+            "alteração de enunciado; metodo=recoleta compara o conteúdo inteiro "
+            "contra a fonte, e recoletado_em guarda a última vez que isso foi feito."
+        ),
+        "conjuntos": dict(sorted(conjuntos.items())),
+    }
+    caminho.parent.mkdir(parents=True, exist_ok=True)
+    caminho.write_text(
+        json.dumps(saida, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    return saida
+
+
 def imprimir_monitoramento(resultado: dict[str, Any]) -> None:
     print(f"Verificação de fontes em {resultado['verificado_em']}")
     sem_mudanca = 0
@@ -2855,6 +2964,16 @@ def parser_cli() -> argparse.ArgumentParser:
         comando = sub.add_parser(acao)
         comando.add_argument("--execucao", required=True)
         comando.add_argument("--conjunto", default="todos")
+        if acao in {"comparar", "executar"}:
+            comando.add_argument(
+                "--registrar",
+                action="store_true",
+                help=(
+                    "registra em base-juridica/verificacoes.json que estes "
+                    "conjuntos foram conferidos por recoleta (conferência forte, "
+                    "que enxerga alteração de enunciado)"
+                ),
+            )
     comando_monitorar = sub.add_parser(
         "monitorar",
         help="verifica sinais de mudança nas fontes sem preparar candidatos",
@@ -2870,6 +2989,25 @@ def parser_cli() -> argparse.ArgumentParser:
         ),
     )
     comando_monitorar.add_argument("--json", action="store_true")
+    comando_monitorar.add_argument(
+        "--json-em",
+        type=Path,
+        default=None,
+        help=(
+            "grava o relatório JSON neste arquivo e mantém o texto no stdout; "
+            "evita ter de monitorar duas vezes para obter os dois formatos, o que "
+            "dobraria as requisições aos portais oficiais"
+        ),
+    )
+    comando_monitorar.add_argument(
+        "--registrar",
+        action="store_true",
+        help=(
+            "grava em base-juridica/verificacoes.json quando cada conjunto foi "
+            "conferido; merge por conjunto, então execuções de pontos de rede "
+            "diferentes se somam em vez de se sobrescrever"
+        ),
+    )
     comando_promover = sub.add_parser("promover")
     comando_promover.add_argument("--execucao", required=True)
     comando_promover.add_argument("--conjunto", default="todos")
@@ -2905,6 +3043,11 @@ def main(argv: list[str] | None = None) -> int:
         ids = [conjunto_id for conjunto_id in ids if conjunto_id not in excluidos]
         resultado = monitorar_conjuntos(dados, ids, publicados)
         resultado["excluidos"] = sorted(excluidos)
+        if args.registrar:
+            registrar_verificacao(resultado, VERIFICACOES_PADRAO)
+            print(f"Registro de verificação atualizado: {VERIFICACOES_PADRAO}")
+        if args.json_em:
+            salvar_json(args.json_em, resultado)
         if args.json:
             print(json.dumps(resultado, ensure_ascii=False, indent=2))
         else:
@@ -2938,6 +3081,13 @@ def main(argv: list[str] | None = None) -> int:
                     f"+{len(item['adicionados'])} -{len(item['removidos'])} "
                     f"~{len(item['alterados'])}"
                 )
+        if getattr(args, "registrar", False):
+            registrar_verificacao(
+                resultado_da_comparacao(relatorio),
+                VERIFICACOES_PADRAO,
+                metodo="recoleta",
+            )
+            print(f"Registro de verificação atualizado: {VERIFICACOES_PADRAO}")
     if args.acao == "promover":
         promover(
             dados,

--- a/ferramentas/manutencao/monitorar-fontes-restritas.sh
+++ b/ferramentas/manutencao/monitorar-fontes-restritas.sh
@@ -34,8 +34,11 @@ trap 'rm -f "$json" "$corpo"' EXIT
 echo "[fontes-restritas] $(date -u +%Y-%m-%dT%H:%M:%SZ) verificando: $FAMILIAS"
 
 # Uma única passada nas fontes (o --json carrega tudo; o texto é formatado daqui).
+# --registrar grava a conferência destas famílias em base-juridica/verificacoes.json;
+# o merge é por conjunto, então isto não apaga o que o monitor da nuvem registrou
+# para as outras — e o contrário também vale.
 python3 ferramentas/manutencao/atualizar_base_juridica.py monitorar \
-  --conjunto "$FAMILIAS" --json > "$json"
+  --conjunto "$FAMILIAS" --registrar --json > "$json"
 
 leia() { python3 -c "import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])" "$json" "$1"; }
 mudancas="$(leia mudancas)"

--- a/ferramentas/manutencao/tests/test_monitorar.py
+++ b/ferramentas/manutencao/tests/test_monitorar.py
@@ -312,6 +312,157 @@ class MonitorarConjuntosTest(unittest.TestCase):
         self.assertNotIn("legislacao/CF", saida)
 
 
+class RegistroDeVerificacaoTest(unittest.TestCase):
+    """O registro responde 'quando isto foi conferido?', não 'quando mudou?'."""
+
+    def resultado(
+        self,
+        conjuntos: dict[str, list[dict[str, str]]],
+        verificado_em: str = "2026-07-29T12:00:00+00:00",
+    ) -> dict[str, object]:
+        return {"verificado_em": verificado_em, "conjuntos": conjuntos}
+
+    def test_grava_conferido_em_por_conjunto(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            alvo = Path(temp) / "verificacoes.json"
+            saida = pipeline.registrar_verificacao(
+                self.resultado(
+                    {
+                        "legislacao": [
+                            {"alvo": "CF", "situacao": "sem_mudanca", "detalhe": "d"},
+                            {"alvo": "CC", "situacao": "sem_mudanca", "detalhe": "d"},
+                        ]
+                    }
+                ),
+                alvo,
+            )
+        registro = saida["conjuntos"]["legislacao"]
+        self.assertEqual(registro["conferido_em"], "2026-07-29T12:00:00+00:00")
+        self.assertEqual(registro["situacao"], "sem_mudanca")
+        self.assertEqual(registro["fontes"], 2)
+
+    def test_execucao_de_outra_rede_nao_apaga_a_anterior(self) -> None:
+        # O monitor da nuvem pula as famílias que exigem rede aceita; elas são
+        # conferidas de outro ponto. Substituir o arquivo perderia uma das duas.
+        with tempfile.TemporaryDirectory() as temp:
+            alvo = Path(temp) / "verificacoes.json"
+            pipeline.registrar_verificacao(
+                self.resultado(
+                    {"legislacao": [{"alvo": "CF", "situacao": "sem_mudanca", "detalhe": "d"}]},
+                    "2026-07-27T09:00:00+00:00",
+                ),
+                alvo,
+            )
+            saida = pipeline.registrar_verificacao(
+                self.resultado(
+                    {"sumulas_stf": [{"alvo": "catalogo", "situacao": "sem_mudanca", "detalhe": "d"}]},
+                    "2026-07-29T12:00:00+00:00",
+                ),
+                alvo,
+            )
+        self.assertEqual(
+            saida["conjuntos"]["legislacao"]["conferido_em"], "2026-07-27T09:00:00+00:00"
+        )
+        self.assertEqual(
+            saida["conjuntos"]["sumulas_stf"]["conferido_em"], "2026-07-29T12:00:00+00:00"
+        )
+
+    def test_erro_nao_conta_como_conferencia(self) -> None:
+        # 403 por IP de datacenter não é conferência: a data antiga permanece, senão
+        # o site afirmaria frescor que ninguém verificou.
+        with tempfile.TemporaryDirectory() as temp:
+            alvo = Path(temp) / "verificacoes.json"
+            pipeline.registrar_verificacao(
+                self.resultado(
+                    {"sumulas_stf": [{"alvo": "catalogo", "situacao": "sem_mudanca", "detalhe": "d"}]},
+                    "2026-07-20T09:00:00+00:00",
+                ),
+                alvo,
+            )
+            saida = pipeline.registrar_verificacao(
+                self.resultado(
+                    {"sumulas_stf": [{"alvo": "catalogo", "situacao": "erro", "detalhe": "403"}]},
+                    "2026-07-29T12:00:00+00:00",
+                ),
+                alvo,
+            )
+        registro = saida["conjuntos"]["sumulas_stf"]
+        self.assertEqual(registro["conferido_em"], "2026-07-20T09:00:00+00:00")
+        self.assertEqual(registro["situacao"], "erro")
+        self.assertEqual(registro["ultimo_erro_em"], "2026-07-29T12:00:00+00:00")
+
+    def test_erro_em_uma_fonte_domina_o_conjunto(self) -> None:
+        itens = [
+            {"alvo": "CF", "situacao": "sem_mudanca", "detalhe": "d"},
+            {"alvo": "CC", "situacao": "erro", "detalhe": "timeout"},
+        ]
+        self.assertEqual(pipeline.situacao_do_conjunto(itens), "erro")
+
+    def test_mudanca_prevalece_sobre_sem_mudanca(self) -> None:
+        itens = [
+            {"alvo": "CF", "situacao": "sem_mudanca", "detalhe": "d"},
+            {"alvo": "CC", "situacao": "mudou", "detalhe": "d"},
+        ]
+        self.assertEqual(pipeline.situacao_do_conjunto(itens), "mudou")
+
+    def test_cli_aceita_registrar(self) -> None:
+        args = pipeline.parser_cli().parse_args(["monitorar", "--registrar"])
+        self.assertTrue(args.registrar)
+
+    def test_cli_aceita_registrar_na_comparacao(self) -> None:
+        args = pipeline.parser_cli().parse_args(
+            ["comparar", "--execucao", "x", "--registrar"]
+        )
+        self.assertTrue(args.registrar)
+
+    def test_sinal_nao_apaga_a_recoleta_anterior(self) -> None:
+        # Um sinal barato de hoje não pode apagar o registro de que a conferência
+        # forte foi feita ontem: elas não valem o mesmo.
+        with tempfile.TemporaryDirectory() as temp:
+            alvo = Path(temp) / "verificacoes.json"
+            pipeline.registrar_verificacao(
+                self.resultado(
+                    {"sumulas_stf": [{"alvo": "s.json", "situacao": "sem_mudanca", "detalhe": "d"}]},
+                    "2026-07-29T20:00:00+00:00",
+                ),
+                alvo,
+                metodo="recoleta",
+            )
+            saida = pipeline.registrar_verificacao(
+                self.resultado(
+                    {"sumulas_stf": [{"alvo": "catalogo", "situacao": "sem_mudanca", "detalhe": "d"}]},
+                    "2026-08-03T09:00:00+00:00",
+                ),
+                alvo,
+                metodo="sinal",
+            )
+        registro = saida["conjuntos"]["sumulas_stf"]
+        self.assertEqual(registro["conferido_em"], "2026-08-03T09:00:00+00:00")
+        self.assertEqual(registro["metodo"], "sinal")
+        self.assertEqual(registro["recoletado_em"], "2026-07-29T20:00:00+00:00")
+
+    def test_comparacao_sem_diferenca_e_sem_mudanca(self) -> None:
+        relatorio = {
+            "gerado_em": "2026-07-29T20:00:00+00:00",
+            "conjuntos": {
+                "sumulas_stf": [
+                    {"arquivo": "sumulas_stf.json", "adicionados": [], "removidos": [], "alterados": []}
+                ],
+                "jurisprudencia_teses_stj": [
+                    {"arquivo": "jt_stj.json", "adicionados": [], "removidos": [], "alterados": ["JT_087_T09"]}
+                ],
+            },
+        }
+        resultado = pipeline.resultado_da_comparacao(relatorio)
+        self.assertEqual(
+            resultado["conjuntos"]["sumulas_stf"][0]["situacao"], "sem_mudanca"
+        )
+        self.assertEqual(
+            resultado["conjuntos"]["jurisprudencia_teses_stj"][0]["situacao"], "mudou"
+        )
+        self.assertEqual(resultado["verificado_em"], "2026-07-29T20:00:00+00:00")
+
+
 class ArvoreHTMLTest(unittest.TestCase):
     def test_fechamento_orfao_de_inline_nao_derruba_o_paragrafo(self) -> None:
         html = (

--- a/ferramentas/pesquisa/vade-mecum/data/jt_stj.json
+++ b/ferramentas/pesquisa/vade-mecum/data/jt_stj.json
@@ -23,7 +23,7 @@
       "Não classificado": 138,
       "Orientações Jurisprudenciais": 71
     },
-    "gerado_em": "2026-07-19",
+    "gerado_em": "2026-07-30",
     "descricao": "Jurisprudência em Teses extraída das páginas oficiais do STJ",
     "transformacao": "jt_stj_html_v1",
     "edicoes_retidas_sem_correspondencia": [
@@ -6735,11 +6735,11 @@
       "edicao_titulo": "LEI DE DROGAS",
       "tese_numero": 13,
       "ramo_direito": "Direito Penal",
-      "enunciado": "Para o deferimento do livramento condicional no crime de associação para o tráfico de drogas, deve ser aplicado o princípio da especialidade, que exige o cumprimento de 2/3 da pena e veda a concessão do benefício ao reincidente específico.",
+      "enunciado": "Por força da incidência do princípio da especialidade, aplica-se a fração de cumprimento de pena prevista no paragrafo único do art. 44 da Lei n. 11.343/2006 ao delito de associação para o tráfico de drogas, previsto no art. 35 dessa lei federal, para fins de deferimento do livramento condicional (Tese julgada sob o rito do art. 1.036 do CPC - Tema n. 1355).",
       "rito_especial": false,
       "data_publicacao": "2015-11-11",
-      "url": "https://scon.stj.jus.br/SCON/GetPDFSelecaoJT?selecao_edicao=45#:~:text=Para%20o%20deferimento%20do%20livramento%20condicional%20no%20crime%20de%20associa%C3%A7%C3%A3o%20para%20o%20tr%C3%A1fico%20de%20drogas%2C%20deve%20ser%20aplicado%20o%20princ%C3%ADpio%20da%20especialidade%2C",
-      "qtd_julgados": 6
+      "url": "https://scon.stj.jus.br/SCON/GetPDFSelecaoJT?selecao_edicao=45#:~:text=Por%20for%C3%A7a%20da%20incid%C3%AAncia%20do%20princ%C3%ADpio%20da%20especialidade%2C%20aplica-se%20a%20fra%C3%A7%C3%A3o%20de%20cumprimento%20de%20pena%20prevista%20no%20paragrafo%20%C3%BAnico%20do%20art.%2044",
+      "qtd_julgados": 7
     },
     "JT_045_T14": {
       "id": "JT_045_T14",
@@ -15279,11 +15279,11 @@
       "edicao_titulo": "CRIMES CONTRA O PATRIMÔNIO - IV",
       "tese_numero": 9,
       "ramo_direito": "Direito Penal",
-      "enunciado": "É possível o reconhecimento da continuidade delitiva de crimes de apropriação indébita previdenciária (art. 168-A do CP), bem como entre o crime de apropriação indébita previdenciária e o crime de sonegação previdenciária (art. 337-A do CP) praticados na administração de empresas distintas, mas pertencentes ao mesmo grupo econômico.",
+      "enunciado": "É inviável reconhecer a continuidade delitiva entre os delitos de apropriação indébita previdenciária (art. 168-A do Código Penal) e de sonegação de contribuição previdenciária (art. 337-A do Código Penal), por se tratarem de espécies diversas que descrevem condutas típicas distintas, embora sejam do mesmo gênero (Tese julgada sob o rito do art. 1.036 do CPC - Tema n. 1353).",
       "rito_especial": false,
       "data_publicacao": "2017-08-23",
-      "url": "https://scon.stj.jus.br/SCON/GetPDFSelecaoJT?selecao_edicao=87#:~:text=%C3%89%20poss%C3%ADvel%20o%20reconhecimento%20da%20continuidade%20delitiva%20de%20crimes%20de%20apropria%C3%A7%C3%A3o%20ind%C3%A9bita%20previdenci%C3%A1ria%20%28art.%20168-A%20do%20CP%29%2C%20bem%20como%20entre%20o%20crime",
-      "qtd_julgados": 3
+      "url": "https://scon.stj.jus.br/SCON/GetPDFSelecaoJT?selecao_edicao=87#:~:text=%C3%89%20invi%C3%A1vel%20reconhecer%20a%20continuidade%20delitiva%20entre%20os%20delitos%20de%20apropria%C3%A7%C3%A3o%20ind%C3%A9bita%20previdenci%C3%A1ria%20%28art.%20168-A%20do%20C%C3%B3digo%20Penal%29%20e%20de%20sonega%C3%A7%C3%A3o%20de",
+      "qtd_julgados": 7
     },
     "JT_087_T10": {
       "id": "JT_087_T10",

--- a/ferramentas/pesquisa/vade-mecum/data/sumulas_stf.json
+++ b/ferramentas/pesquisa/vade-mecum/data/sumulas_stf.json
@@ -4,7 +4,7 @@
     "tipo": "sumulas",
     "tribunal": "STF",
     "total": 736,
-    "gerado_em": "2026-07-19",
+    "gerado_em": "2026-07-30",
     "descricao": "Súmulas extraídas do catálogo oficial do STF",
     "transformacao": "sumulas_stf_html_v1",
     "ativas": 724,
@@ -124,7 +124,29 @@
       "status": "ativa",
       "area": "Administrativo",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula14/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula14/false",
+      "precedentes": [
+        {
+          "processo": "ARE 678.112 RG",
+          "relator": "Luiz Fux",
+          "orgao": "P",
+          "julgamento": "25/04/2013",
+          "publicacao": "DJE 93 de 17-5-2013",
+          "url": "https://www.stf.jus.br/portal/inteiroTeor/obterInteiroTeor.asp?numero=678112&classe=ARE-RG",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=ARE%20678112",
+          "temaRG": 646
+        },
+        {
+          "processo": "RE 600.885",
+          "relator": "Cármen Lúcia",
+          "orgao": "P",
+          "julgamento": "09/02/2011",
+          "publicacao": "DJE 125 de 1º-7-2011",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=624857",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20600885",
+          "temaRG": 121
+        }
+      ]
     },
     "15": {
       "numero": 15,
@@ -132,7 +154,39 @@
       "status": "ativa",
       "area": "Administrativo",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula15/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula15/false",
+      "precedentes": [
+        {
+          "processo": "RE 837.311",
+          "relator": "Luiz Fux",
+          "orgao": "P",
+          "julgamento": "09/12/2015",
+          "publicacao": "DJE 72 de 18-4-2016",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=10744965",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20837311",
+          "temaRG": 784
+        },
+        {
+          "processo": "RE 724.347",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "26/02/2015",
+          "publicacao": "DJE 88 de 13-5-2015",
+          "url": "https://www.stf.jus.br/portal/inteiroTeor/obterInteiroTeor.asp?idDocumento=8429975",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20724347",
+          "temaRG": 671
+        },
+        {
+          "processo": "RE 598.099",
+          "relator": "Gilmar Mendes",
+          "orgao": "P",
+          "julgamento": "10/08/2011",
+          "publicacao": "DJE 189 de 3-10-2011",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=628215",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20598099",
+          "temaRG": 161
+        }
+      ]
     },
     "16": {
       "numero": 16,
@@ -228,7 +282,76 @@
       "status": "ativa",
       "area": "Administrativo",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula27/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula27/false",
+      "precedentes": [
+        {
+          "processo": "RE 563.708",
+          "relator": "Cármen Lúcia",
+          "orgao": "P",
+          "julgamento": "06/02/2013",
+          "publicacao": "DJE 81 de 2-5-2013",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=3716931",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20563708",
+          "temaRG": 24
+        },
+        {
+          "processo": "RE 593.304 AgR",
+          "relator": "Eros Grau",
+          "orgao": "2ª T",
+          "julgamento": "29/09/2009",
+          "publicacao": "DJE 200 de 23-10-2009",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=604718",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20593304"
+        },
+        {
+          "processo": "RE 298.694",
+          "relator": "Sepúlveda Pertence",
+          "orgao": "P",
+          "julgamento": "06/08/2003",
+          "publicacao": "DJ de 23-4-2004",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=260435",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20298694"
+        },
+        {
+          "processo": "ADI 2.075 MC",
+          "relator": "Celso de Mello",
+          "orgao": "P",
+          "julgamento": "07/02/2001",
+          "publicacao": "DJ de 27-6-2003",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=347415",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=ADI%202075"
+        },
+        {
+          "processo": "ARE 660.010 RG",
+          "relator": "Dias Toffoli",
+          "orgao": "P",
+          "julgamento": "02/02/2012",
+          "publicacao": "DJE 98 de 21-5-2012",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=2019531",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=ARE%20660010",
+          "temaRG": 514
+        },
+        {
+          "processo": "RE 609.381 RG",
+          "relator": "Ayres Britto",
+          "orgao": "P",
+          "julgamento": "22/09/2011",
+          "publicacao": "DJE 84 de 2-5-2012",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=1955293",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20609381",
+          "temaRG": 480
+        },
+        {
+          "processo": "ARE 637.607 RG",
+          "relator": "Luiz Fux",
+          "orgao": "P",
+          "julgamento": "23/06/2011",
+          "publicacao": "DJE 171 de 6-9-2011",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=627061",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=ARE%20637607",
+          "temaRG": 440
+        }
+      ]
     },
     "28": {
       "numero": 28,
@@ -572,7 +695,39 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula70/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula70/false",
+      "precedentes": [
+        {
+          "processo": "ARE 914.045 RG",
+          "relator": "Edson Fachin",
+          "orgao": "P",
+          "julgamento": "15/10/2015",
+          "publicacao": "DJE 32 de 19-11-2015",
+          "url": "https://www.stf.jus.br/portal/inteiroTeor/obterInteiroTeor.asp?numero=914045&classe=ARE-RG",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=ARE%20914045",
+          "temaRG": 856
+        },
+        {
+          "processo": "RE 565.048",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "29/05/2014",
+          "publicacao": "DJE 197 de 9-10-2014",
+          "url": "https://www.stf.jus.br/portal/inteiroTeor/obterInteiroTeor.asp?idDocumento=6911989",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20565048",
+          "temaRG": 31
+        },
+        {
+          "processo": "RE 627.543",
+          "relator": "Dias Toffoli",
+          "orgao": "P",
+          "julgamento": "30/10/2013",
+          "publicacao": "DJE 212 de 29-10-2014",
+          "url": "https://www.stf.jus.br/portal/inteiroTeor/obterInteiroTeor.asp?idDocumento=7066469",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20627543",
+          "temaRG": 363
+        }
+      ]
     },
     "71": {
       "numero": 71,
@@ -580,7 +735,18 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula71/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula71/false",
+      "precedentes": [
+        {
+          "processo": "RE 593.849",
+          "relator": "Edson Fachin",
+          "orgao": "P",
+          "julgamento": "19/10/2016",
+          "publicacao": "DJE 177 de 31-3-2017 - tema 201",
+          "url": "https://www.stf.jus.br/portal/inteiroTeor/obterInteiroTeor.asp?idDocumento=12692057",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20593849"
+        }
+      ]
     },
     "72": {
       "numero": 72,
@@ -620,7 +786,18 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula76/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula76/false",
+      "precedentes": [
+        {
+          "processo": "RE 594.015",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "06/04/2017",
+          "publicacao": "DJE 188 de 25-8-2017 - Tema 385",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=13440489",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20594015"
+        }
+      ]
     },
     "77": {
       "numero": 77,
@@ -660,7 +837,19 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula81/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula81/false",
+      "precedentes": [
+        {
+          "processo": "RE 598.085",
+          "relator": "Luiz Fux",
+          "orgao": "P",
+          "julgamento": "06/11/2014",
+          "publicacao": "DJE 27 de 10-2-2015",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=7708834",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20598085",
+          "temaRG": 177
+        }
+      ]
     },
     "82": {
       "numero": 82,
@@ -980,7 +1169,19 @@
       "status": "ativa",
       "area": "Civil",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula121/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula121/false",
+      "precedentes": [
+        {
+          "processo": "RE 592.377",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "04/02/2015",
+          "publicacao": "DJE 55 de 20-3-2015",
+          "url": "https://www.stf.jus.br/portal/inteiroTeor/obterInteiroTeor.asp?idDocumento=8051145",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20592377",
+          "temaRG": 33
+        }
+      ]
     },
     "122": {
       "numero": 122,
@@ -1172,7 +1373,19 @@
       "status": "ativa",
       "area": "Penal",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula145/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula145/false",
+      "precedentes": [
+        {
+          "processo": "RE 583937 QO-RG",
+          "relator": "Cezar Peluso",
+          "orgao": "P",
+          "julgamento": "19/11/2009",
+          "publicacao": "DJE 237 de 18-12-2009",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=607025",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20583937-RG",
+          "temaRG": 237
+        }
+      ]
     },
     "146": {
       "numero": 146,
@@ -1676,7 +1889,19 @@
       "status": "ativa",
       "area": "Processual Penal",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula208/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula208/false",
+      "precedentes": [
+        {
+          "processo": "ARE 859.251 RG",
+          "relator": "Gilmar Mendes",
+          "orgao": "P",
+          "julgamento": "16/04/2015",
+          "publicacao": "DJE 94 de 21-5-2015",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=8522862",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=ARE%20859251",
+          "temaRG": 811
+        }
+      ]
     },
     "209": {
       "numero": 209,
@@ -1892,7 +2117,19 @@
       "status": "ativa",
       "area": "Processual do Trabalho",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula235/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula235/false",
+      "precedentes": [
+        {
+          "processo": "RE 638.483 RG",
+          "relator": "presidente Cezar Peluso",
+          "orgao": "P",
+          "julgamento": "09/06/2011",
+          "publicacao": "DJE 167 de 31-8-2011",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=626888",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20638483",
+          "temaRG": 414
+        }
+      ]
     },
     "236": {
       "numero": 236,
@@ -2148,7 +2385,19 @@
       "status": "ativa",
       "area": "Processual Civil",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula267/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula267/false",
+      "precedentes": [
+        {
+          "processo": "RE 576.847",
+          "relator": "Eros Grau",
+          "orgao": "P",
+          "julgamento": "20/05/2009",
+          "publicacao": "DJE de 7-8-2009",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=599660",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20576847",
+          "temaRG": 77
+        }
+      ]
     },
     "268": {
       "numero": 268,
@@ -2164,7 +2413,19 @@
       "status": "ativa",
       "area": "Processual Civil",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula269/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula269/false",
+      "precedentes": [
+        {
+          "processo": "RE 553.710",
+          "relator": "Dias Toffoli",
+          "orgao": "P",
+          "julgamento": "23/11/2016",
+          "publicacao": "DJE 195 de 31-8-2017",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=13499625",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20553710",
+          "temaRG": 394
+        }
+      ]
     },
     "270": {
       "numero": 270,
@@ -2436,7 +2697,19 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula303/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula303/false",
+      "precedentes": [
+        {
+          "processo": "RE 608.872",
+          "relator": "Dias Toffoli",
+          "orgao": "P",
+          "julgamento": "23/02/2017",
+          "publicacao": "DJE 219 de 6-3-2017",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=13686215",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20608872",
+          "temaRG": 342
+        }
+      ]
     },
     "304": {
       "numero": 304,
@@ -2508,7 +2781,19 @@
       "status": "ativa",
       "area": "Trabalhista",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula312/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula312/false",
+      "precedentes": [
+        {
+          "processo": "RE 795.467 RG",
+          "relator": "Teori Zavascki",
+          "orgao": "P",
+          "julgamento": "05/06/2014",
+          "publicacao": "DJE 122 de 24-6-2014",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=6242682",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20795467",
+          "temaRG": 738
+        }
+      ]
     },
     "313": {
       "numero": 313,
@@ -2596,7 +2881,49 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula323/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula323/false",
+      "precedentes": [
+        {
+          "processo": "ARE 914.045 RG",
+          "relator": "Edson Fachin",
+          "orgao": "P",
+          "julgamento": "15/10/2015",
+          "publicacao": "DJE 232 de 19-11-2015",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=9816024",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=ARE%20914045",
+          "temaRG": 856
+        },
+        {
+          "processo": "RE 565.048",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "29/05/2014",
+          "publicacao": "DJE 197 de 9-10-2014",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=6911989",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20565048",
+          "temaRG": 31
+        },
+        {
+          "processo": "RE 565048",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "29/05/2014",
+          "publicacao": "DJE 197 de 9-10-2014",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=6911989",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20565048",
+          "temaRG": 31
+        },
+        {
+          "processo": "RE 627.543",
+          "relator": "Dias Toffoli",
+          "orgao": "P",
+          "julgamento": "30/10/2013",
+          "publicacao": "DJE 212 de 29-10-2014",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=7066469",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20627543",
+          "temaRG": 363
+        }
+      ]
     },
     "324": {
       "numero": 324,
@@ -2756,7 +3083,47 @@
       "status": "ativa",
       "area": "Processual Civil",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula343/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula343/false",
+      "precedentes": [
+        {
+          "processo": "RE 730.462",
+          "relator": "Teori Zavascki",
+          "orgao": "P",
+          "julgamento": "28/05/2015",
+          "publicacao": "DJE 177 de 9-9-2015",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=9343495",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20730462",
+          "temaRG": 733
+        },
+        {
+          "processo": "RE 590.809",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "22/10/2014",
+          "publicacao": "DJE 230 de 24-11-2014",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=7303880",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20590809",
+          "temaRG": 136
+        },
+        {
+          "processo": "AR 2.377-AgR",
+          "relator": "Luiz Fux",
+          "orgao": "P",
+          "julgamento": "13/06/2023",
+          "publicacao": "DJE s/n de 27-6-2023",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=768903077",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=AR%202377-AgR"
+        },
+        {
+          "processo": "AR 2.928-AgR",
+          "relator": "Rosa Weber",
+          "orgao": "P",
+          "julgamento": "13/12/2022",
+          "publicacao": "DJE 13 de 25-1-2023",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=765202183",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=AR%202928-AgR"
+        }
+      ]
     },
     "344": {
       "numero": 344,
@@ -2780,7 +3147,19 @@
       "status": "ativa",
       "area": "Administrativo",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula346/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula346/false",
+      "precedentes": [
+        {
+          "processo": "RE 594.296",
+          "relator": "Dias Toffoli",
+          "orgao": "P",
+          "julgamento": "21/09/2011",
+          "publicacao": "DJE 30 de 13-2-2012",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=1729772",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20594296",
+          "temaRG": 138
+        }
+      ]
     },
     "347": {
       "numero": 347,
@@ -2884,7 +3263,19 @@
       "status": "alterada",
       "area": "Administrativo",
       "data": "13/12/1963",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula359/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula359/false",
+      "precedentes": [
+        {
+          "processo": "RE 630.501",
+          "relator": "Ellen Gracie",
+          "orgao": "P",
+          "julgamento": "21/02/2013",
+          "publicacao": "DJE de 26-8-2013",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=630025",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20630501",
+          "temaRG": 334
+        }
+      ]
     },
     "360": {
       "numero": 360,
@@ -2988,7 +3379,19 @@
       "status": "ativa",
       "area": "Não classificado",
       "data": "03/04/1964",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula372/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula372/false",
+      "precedentes": [
+        {
+          "processo": "RE 630.501",
+          "relator": "Ellen Gracie",
+          "orgao": "P",
+          "julgamento": "21/02/2013",
+          "publicacao": "DJE 166 de 26-08-2013",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=630025",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20630501",
+          "temaRG": 334
+        }
+      ]
     },
     "373": {
       "numero": 373,
@@ -3244,7 +3647,19 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "03/04/1964",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula404/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula404/false",
+      "precedentes": [
+        {
+          "processo": "RE 570.680",
+          "relator": "Ricardo Lewandowski",
+          "orgao": "P",
+          "julgamento": "28/10/2009",
+          "publicacao": "DJE 228 de 4-12-2009",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=606568",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20570680",
+          "temaRG": 53
+        }
+      ]
     },
     "405": {
       "numero": 405,
@@ -3556,7 +3971,19 @@
       "status": "ativa",
       "area": "Administrativo",
       "data": "01/10/1964",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula443/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula443/false",
+      "precedentes": [
+        {
+          "processo": "RE 626.489",
+          "relator": "Roberto Barroso",
+          "orgao": "P",
+          "julgamento": "16/10/2013",
+          "publicacao": "DJE 184 de 23-9-2014",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=6760827",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20626489",
+          "temaRG": 313
+        }
+      ]
     },
     "444": {
       "numero": 444,
@@ -3572,7 +3999,19 @@
       "status": "ativa",
       "area": "Civil",
       "data": "01/10/1964",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula445/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula445/false",
+      "precedentes": [
+        {
+          "processo": "RE 566.621",
+          "relator": "Ellen Gracie",
+          "orgao": "P",
+          "julgamento": "04/08/2011",
+          "publicacao": "DJE 195 de 11-10-2011",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=628479",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20566621",
+          "temaRG": 4
+        }
+      ]
     },
     "446": {
       "numero": 446,
@@ -3620,7 +4059,29 @@
       "status": "ativa",
       "area": "Processual Penal",
       "data": "01/10/1964",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula452/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula452/false",
+      "precedentes": [
+        {
+          "processo": "RE 549.560",
+          "relator": "Ricardo Lewandowski",
+          "orgao": "P",
+          "julgamento": "22/03/2012",
+          "publicacao": "DJE 104 de 30-5-2014",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=630070",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20549560",
+          "temaRG": 453
+        },
+        {
+          "processo": "AP 937 QO",
+          "relator": "Roberto Barroso",
+          "orgao": "P",
+          "julgamento": "03/05/2018",
+          "publicacao": "DJE 265 de 11-12-2018",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=748842078",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=AP%20937",
+          "temaRG": 453
+        }
+      ]
     },
     "452": {
       "numero": 452,
@@ -3660,7 +4121,19 @@
       "status": "ativa",
       "area": "Processual Civil",
       "data": "01/10/1964",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula456/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula456/false",
+      "precedentes": [
+        {
+          "processo": "RE 636.331",
+          "relator": "Gilmar Mendes",
+          "orgao": "P",
+          "julgamento": "25/05/2017",
+          "publicacao": "DJE 257 de 13-11-2017",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=14028416",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20636331",
+          "temaRG": 210
+        }
+      ]
     },
     "457": {
       "numero": 457,
@@ -3756,7 +4229,19 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "01/10/1964",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula468/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula468/false",
+      "precedentes": [
+        {
+          "processo": "RE 608.872",
+          "relator": "Dias Toffoli",
+          "orgao": "P",
+          "julgamento": "23/02/2017",
+          "publicacao": "DJE 219 de 6-3-2017",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=1322823",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20608872",
+          "temaRG": 342
+        }
+      ]
     },
     "469": {
       "numero": 469,
@@ -3796,7 +4281,19 @@
       "status": "ativa",
       "area": "Administrativo",
       "data": "03/12/1969",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula473/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula473/false",
+      "precedentes": [
+        {
+          "processo": "RE 594.296",
+          "relator": "Dias Toffoli",
+          "orgao": "P",
+          "julgamento": "21/09/2011",
+          "publicacao": "DJE 146 de 13-2-2012",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=1729772",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20594296",
+          "temaRG": 138
+        }
+      ]
     },
     "474": {
       "numero": 474,
@@ -4020,7 +4517,19 @@
       "status": "ativa",
       "area": "Processual do Trabalho",
       "data": "03/12/1969",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula501/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula501/false",
+      "precedentes": [
+        {
+          "processo": "RE 638.483 RG",
+          "relator": "presidente Cezar Peluso",
+          "orgao": "P",
+          "julgamento": "09/06/2011",
+          "publicacao": "DJE 167 de 31-8-2011",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=626888",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20638483",
+          "temaRG": 414
+        }
+      ]
     },
     "502": {
       "numero": 502,
@@ -4252,7 +4761,19 @@
       "status": "ativa",
       "area": "Previdenciário",
       "data": "03/12/1969",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula530/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula530/false",
+      "precedentes": [
+        {
+          "processo": "RE 593.068 RG",
+          "relator": "Roberto Barroso",
+          "orgao": "P",
+          "julgamento": "07/05/2009",
+          "publicacao": "DJE 94 de 22-05-2009",
+          "url": "https://portal.stf.jus.br/processos/detalhe.asp?incidente=2639193",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20593068",
+          "temaRG": 163
+        }
+      ]
     },
     "531": {
       "numero": 531,
@@ -4388,7 +4909,39 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "03/12/1969",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula547/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula547/false",
+      "precedentes": [
+        {
+          "processo": "ARE 914.045 RG",
+          "relator": "Edson Fachin",
+          "orgao": "P",
+          "julgamento": "15/10/2015",
+          "publicacao": "DJE 232 de 19-11-2015",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=9816024",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=ARE%20914045",
+          "temaRG": 856
+        },
+        {
+          "processo": "RE 627.543",
+          "relator": "Dias Toffoli",
+          "orgao": "P",
+          "julgamento": "30/10/2013",
+          "publicacao": "DJE 117 de 29-10-2014",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=7066469",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20627543",
+          "temaRG": 363
+        },
+        {
+          "processo": "RE 565.048",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "29/05/2014",
+          "publicacao": "DJE 65 de 9-10-2014",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=6911989",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20565048",
+          "temaRG": 31
+        }
+      ]
     },
     "548": {
       "numero": 548,
@@ -4588,7 +5141,19 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "15/12/1976",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula572/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula572/false",
+      "precedentes": [
+        {
+          "processo": "RE 606.107",
+          "relator": "Rosa Weber",
+          "orgao": "P",
+          "julgamento": "22/05/2013",
+          "publicacao": "DJE 231 de 25-11-2013",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=4919271",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20606107",
+          "temaRG": 283
+        }
+      ]
     },
     "573": {
       "numero": 573,
@@ -4636,7 +5201,19 @@
       "status": "ativa",
       "area": "Constitucional",
       "data": "15/12/1976",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula578/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula578/false",
+      "precedentes": [
+        {
+          "processo": "RE 572.762",
+          "relator": "Ricardo Lewandowski",
+          "orgao": "P",
+          "julgamento": "18/06/2008",
+          "publicacao": "DJE 167 de 5-9-2008",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=546141",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20572762",
+          "temaRG": 42
+        }
+      ]
     },
     "579": {
       "numero": 579,
@@ -4676,7 +5253,27 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "15/12/1976",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula583/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula583/false",
+      "precedentes": [
+        {
+          "processo": "RE 601.720",
+          "relator": "Edson Fachin",
+          "orgao": "P",
+          "julgamento": "19/04/2017",
+          "publicacao": "DJE 200 de 5-9-2017 - Tema 437",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=13534812",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20601720"
+        },
+        {
+          "processo": "RE 594.015",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "06/04/2017",
+          "publicacao": "DJE 188 de 25-8-2017 - Tema 385",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=13440489",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20594015"
+        }
+      ]
     },
     "584": {
       "numero": 584,
@@ -4684,7 +5281,19 @@
       "status": "cancelada",
       "area": "Tributário",
       "data": "15/12/1976",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula584/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula584/false",
+      "precedentes": [
+        {
+          "processo": "RE 592.396",
+          "relator": "Edson Fachin",
+          "orgao": "P",
+          "julgamento": "03/12/2015",
+          "publicacao": "DJE 54 de 28-3-2016",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=10559727",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20592396",
+          "temaRG": 168
+        }
+      ]
     },
     "585": {
       "numero": 585,
@@ -4740,7 +5349,19 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "15/12/1976",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula591/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula591/false",
+      "precedentes": [
+        {
+          "processo": "RE 608.872",
+          "relator": "Dias Toffoli",
+          "orgao": "P",
+          "julgamento": "23/02/2017",
+          "publicacao": "DJE 219 de 27-9-2017",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=13686215",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20608872",
+          "temaRG": 342
+        }
+      ]
     },
     "592": {
       "numero": 592,
@@ -4780,7 +5401,19 @@
       "status": "ativa",
       "area": "Civil",
       "data": "15/12/1976",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula596/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula596/false",
+      "precedentes": [
+        {
+          "processo": "RE 592.377",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "04/02/2015",
+          "publicacao": "DJE 55 de 20-3-2015",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=8051145",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20592377",
+          "temaRG": 33
+        }
+      ]
     },
     "597": {
       "numero": 597,
@@ -5044,7 +5677,29 @@
       "status": "ativa",
       "area": "Processual Civil",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula629/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula629/false",
+      "precedentes": [
+        {
+          "processo": "RE 612.043",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "10/05/2017",
+          "publicacao": "DJE 229 de 6-10-2017",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=13743622",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20612043",
+          "temaRG": 499
+        },
+        {
+          "processo": "RE 573.232",
+          "relator": "Ricardo Lewandowski",
+          "orgao": "P",
+          "julgamento": "14/05/2014",
+          "publicacao": "DJE 182 de 19-9-2014",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=630085",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20573232",
+          "temaRG": 82
+        }
+      ]
     },
     "630": {
       "numero": 630,
@@ -5052,7 +5707,29 @@
       "status": "ativa",
       "area": "Processual Civil",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula630/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula630/false",
+      "precedentes": [
+        {
+          "processo": "RE 612.043",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "10/05/2017",
+          "publicacao": "DJE 229 de 6-10-2017",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=13743622",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20612043",
+          "temaRG": 499
+        },
+        {
+          "processo": "RE 573.232",
+          "relator": "Ricardo Lewandowski",
+          "orgao": "P",
+          "julgamento": "14/05/2014",
+          "publicacao": "DJE 182 de 19-9-2014",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=630085",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20573232",
+          "temaRG": 82
+        }
+      ]
     },
     "631": {
       "numero": 631,
@@ -5132,7 +5809,19 @@
       "status": "ativa",
       "area": "Processual Civil",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula640/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula640/false",
+      "precedentes": [
+        {
+          "processo": "RE 590.409",
+          "relator": "Ricardo Lewandowski",
+          "orgao": "P",
+          "julgamento": "26/08/2009",
+          "publicacao": "DJE 204 de 29-10-2009",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=605201",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20590409",
+          "temaRG": 128
+        }
+      ]
     },
     "641": {
       "numero": 641,
@@ -5268,7 +5957,19 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula657/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula657/false",
+      "precedentes": [
+        {
+          "processo": "RE 330.817",
+          "relator": "Dias Toffoli",
+          "orgao": "P",
+          "julgamento": "08/03/2017",
+          "publicacao": "DJE 195 de 31-8-2017",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=13501630",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20330817",
+          "temaRG": 593
+        }
+      ]
     },
     "658": {
       "numero": 658,
@@ -5292,7 +5993,19 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula660/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula660/false",
+      "precedentes": [
+        {
+          "processo": "RE 439.796",
+          "relator": "Joaquim Barbosa",
+          "orgao": "P",
+          "julgamento": "06/11/2013",
+          "publicacao": "DJE 51 de 17-3-2014",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=5473460",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20439796",
+          "temaRG": 171
+        }
+      ]
     },
     "661": {
       "numero": 661,
@@ -5356,7 +6069,29 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula668/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula668/false",
+      "precedentes": [
+        {
+          "processo": "RE 602.347",
+          "relator": "Edson Fachin",
+          "orgao": "P",
+          "julgamento": "04/11/2015",
+          "publicacao": "DJE 67 de 12-4-2016",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=10676798",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20602347",
+          "temaRG": 226
+        },
+        {
+          "processo": "AI 712.743 QO-RG",
+          "relator": "Ellen Gracie",
+          "orgao": "P",
+          "julgamento": "12/09/2009",
+          "publicacao": "DJE 84 de 8-5-2009",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=591931",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=AI%20712743-RG",
+          "temaRG": 155
+        }
+      ]
     },
     "669": {
       "numero": 669,
@@ -5388,7 +6123,19 @@
       "status": "ativa",
       "area": "Administrativo",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula672/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula672/false",
+      "precedentes": [
+        {
+          "processo": "RE 584.313 QO RG",
+          "relator": "Gilmar Mendes",
+          "orgao": "P",
+          "julgamento": "06/10/2010",
+          "publicacao": "DJE 200 de 22-10-2010",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=615757",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20584313",
+          "temaRG": 340
+        }
+      ]
     },
     "673": {
       "numero": 673,
@@ -5396,7 +6143,19 @@
       "status": "ativa",
       "area": "Militar",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula673/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula673/false",
+      "precedentes": [
+        {
+          "processo": "ARE 691.306 RG",
+          "relator": "Cezar Peluso",
+          "orgao": "P",
+          "julgamento": "23/08/2012",
+          "publicacao": "DJE 178 de 11-9-2012",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=2709841",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=ARE%20691306",
+          "temaRG": 565
+        }
+      ]
     },
     "674": {
       "numero": 674,
@@ -5476,7 +6235,19 @@
       "status": "ativa",
       "area": "Administrativo",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula683/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula683/false",
+      "precedentes": [
+        {
+          "processo": "ARE 678.112 RG",
+          "relator": "Luiz Fux",
+          "orgao": "P",
+          "julgamento": "25/04/2013",
+          "publicacao": "DJE 93 de 17-5-2016",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=3791863",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=ARE%20678112",
+          "temaRG": 646
+        }
+      ]
     },
     "684": {
       "numero": 684,
@@ -5484,7 +6255,39 @@
       "status": "ativa",
       "area": "Administrativo",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula684/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula684/false",
+      "precedentes": [
+        {
+          "processo": "RE 632.853",
+          "relator": "Gilmar Mendes",
+          "orgao": "P",
+          "julgamento": "23/04/2015",
+          "publicacao": "DJE 125 de 29-6-2015",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=8773734",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20632853",
+          "temaRG": 485
+        },
+        {
+          "processo": "RE 630.733",
+          "relator": "Gilmar Mendes",
+          "orgao": "P",
+          "julgamento": "15/05/2013",
+          "publicacao": "DJE 228 de 20-11-2013",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=4887206",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20630733",
+          "temaRG": 335
+        },
+        {
+          "processo": "AI 758.533 QO",
+          "relator": "Gilmar Mendes",
+          "orgao": "P",
+          "julgamento": "23/06/2010",
+          "publicacao": "DJE 149 de 13-8-2010",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=613387",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=AI%20758533",
+          "temaRG": 338
+        }
+      ]
     },
     "685": {
       "numero": 685,
@@ -5500,7 +6303,27 @@
       "status": "ativa",
       "area": "Administrativo",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula686/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula686/false",
+      "precedentes": [
+        {
+          "processo": "RE 898.450 RG",
+          "relator": "Luiz Fux",
+          "orgao": "P",
+          "julgamento": "27/08/2015",
+          "publicacao": "",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=9352600",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20898450"
+        },
+        {
+          "processo": "ARE 678.112 RG",
+          "relator": "Luiz Fux",
+          "orgao": "P",
+          "julgamento": "25/04/2013",
+          "publicacao": "",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=3791863",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=ARE%20678112"
+        }
+      ]
     },
     "687": {
       "numero": 687,
@@ -5516,7 +6339,19 @@
       "status": "ativa",
       "area": "Previdenciário",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula688/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula688/false",
+      "precedentes": [
+        {
+          "processo": "RE 565.160",
+          "relator": "Marco Aurélio",
+          "orgao": "P",
+          "julgamento": "29/03/2017",
+          "publicacao": "DJE 186 de 23-8-2017",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=13413144",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20565160",
+          "temaRG": 20
+        }
+      ]
     },
     "689": {
       "numero": 689,
@@ -5588,7 +6423,19 @@
       "status": "ativa",
       "area": "Processual Penal",
       "data": "24/09/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula697/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula697/false",
+      "precedentes": [
+        {
+          "processo": "RE 1.038.925 RG",
+          "relator": "Gilmar Mendes",
+          "orgao": "P",
+          "julgamento": "18/08/2017",
+          "publicacao": "DJE de 19-9-2017",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=13625646",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%201038925",
+          "temaRG": 959
+        }
+      ]
     },
     "698": {
       "numero": 698,
@@ -5820,7 +6667,28 @@
       "status": "ativa",
       "area": "Administrativo",
       "data": "26/11/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula726/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula726/false",
+      "precedentes": [
+        {
+          "processo": "RE 1.039.644 RG",
+          "relator": "Alexandre de Moraes",
+          "orgao": "P",
+          "julgamento": "12/10/2017",
+          "publicacao": "DJE 257 de 13-11-2017",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=14027801",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%201039644",
+          "temaRG": 965
+        },
+        {
+          "processo": "ADI 3.772",
+          "relator": "Ayres Britto",
+          "orgao": "P",
+          "julgamento": "29/10/2008",
+          "publicacao": "DJE 204 de 27-3-2009",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=AC&docID=605033",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=ADI%203772"
+        }
+      ]
     },
     "727": {
       "numero": 727,
@@ -5868,7 +6736,19 @@
       "status": "ativa",
       "area": "Tributário",
       "data": "26/11/2003",
-      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula732/false"
+      "url": "https://jurisprudencia.stf.jus.br/pages/search/seq-sumula732/false",
+      "precedentes": [
+        {
+          "processo": "RE 660.933 RG",
+          "relator": "Joaquim Barbosa",
+          "orgao": "P",
+          "julgamento": "02/02/2012",
+          "publicacao": "DJE 37 de 23-2-2012",
+          "url": "https://redir.stf.jus.br/paginadorpub/paginador.jsp?docTP=TP&docID=1748913",
+          "consulta": "https://jurisprudencia.stf.jus.br/pages/search?base=acordaos&sinonimo=true&plural=true&page=1&pageSize=10&sort=_score&sortBy=desc&isAdvance=true&classeNumeroIncidente=RE%20660933",
+          "temaRG": 518
+        }
+      ]
     },
     "733": {
       "numero": 733,

--- a/ferramentas/pesquisa/vade-mecum/data/sumulas_stf_keywords.json
+++ b/ferramentas/pesquisa/vade-mecum/data/sumulas_stf_keywords.json
@@ -21,9 +21,9 @@
     "fonte": {
       "arquivo": "sumulas_stf.json",
       "colecao": "sumulas",
-      "sha256": "e9e84c1296a46929fe2f2eaf4924f79a272ff7c5ab7fc667e297f9b253f5f324",
+      "sha256": "4d54cf7b46aae8d0f9b6b78df4eec14386b478b54c2df1763f9a9ca0329de648",
       "total_registros": 736,
-      "gerado_em": "2026-07-19"
+      "gerado_em": "2026-07-30"
     },
     "relacao": {
       "chave": "numero",


### PR DESCRIPTION
Duas coisas: corrige dado jurídico errado na base e cria o registro que faltava para se poder afirmar "conferido".

## 1. A base afirmava o oposto do STJ em uma tese

Achado por **recoleta completa** dos 30 conjuntos, não pelo monitor — os sinais baratos deram "sem mudança" nas 288 fontes.

**JT_087_T09** (Jurisprudência em Teses, ed. 87):

| | Enunciado |
|---|---|
| **Antes** | "É **possível** o reconhecimento da continuidade delitiva de crimes de apropriação indébita previdenciária (art. 168-A do CP), bem como entre o crime de apropriação indébita previdenciária e o crime de sonegação previdenciária (art. 337-A do CP)…" |
| **Agora** | "É **inviável** reconhecer a continuidade delitiva entre os delitos de apropriação indébita previdenciária (art. 168-A do Código Penal) e de sonegação de contribuição previdenciária (art. 337-A do Código Penal)… *(Tese julgada sob o rito do art. 1.036 do CPC - Tema n. 1353)*" |

**JT_045_T13** (ed. 45): reformulada e ancorada no parágrafo único do art. 44 da Lei 11.343/2006, com referência ao **Tema 1355**.

Os links com âncora `#:~:text=` acompanharam os novos enunciados — citavam a redação antiga e deixariam de casar no PDF oficial.

**Súmulas do STF:** 51 registros ganham `precedentes` (de `null` para lista populada). Não é mudança na fonte: é o transformador que passou a capturar a seção oficial de precedentes representativos.

Conferido registro a registro: **zero enunciados de súmula alterados na base inteira**, zero adições, zero remoções. Nenhum gate acionado (51 de 736 = 6,9%). Os outros 283 arquivos vieram idênticos à fonte e por isso **não** foram promovidos — promover sem diferença só trocaria timestamps e inflaria versões.

## 2. Registro de conferência (`verificacoes.json`)

`snapshots.json` responde "quando mudou?". Faltava "quando foi conferido?". Sem isso, família estável desde junho aparece no site como abandonada desde junho.

Três decisões que o registro respeita:

- **`metodo` separa as forças:** `sinal` (monitor barato) **não vê alteração de enunciado**; `recoleta` compara o conteúdo inteiro. `recoletado_em` nunca é sobrescrito por um sinal.
- **Merge por conjunto:** o monitor da nuvem pula as 6 famílias que exigem rede aceita; reescrever o arquivo faria uma execução apagar a conferência da outra.
- **Erro não é conferência:** 403 ou timeout preserva a data anterior e vai para `ultimo_erro_em`.

Também: `monitorar --json-em` elimina a segunda passada que dobrava as requisições aos portais oficiais toda semana; os dois monitores passam a registrar e commitar.

## Verificação

- validação sem erros; índices derivados regenerados (`sumulas_stf_keywords`);
- `snapshots.json` atualizado (`jt_stj` v2, `sumulas_stf` v2), `--verificar` coerente em 285 arquivos;
- `auditar_base_juridica.py --strict` sem inconsistências; compatibilidade das skills validada;
- **111 testes Python** (9 novos no registro) e **58 do motor**; `typecheck` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
