### PR TITLE
fix(base): `gerado_em` preserva o instante, para o dia poder ser local

### DIFF
--- a/ferramentas/manutencao/atualizar_base_juridica.py
+++ b/ferramentas/manutencao/atualizar_base_juridica.py
@@ -79,6 +79,13 @@ def agora_utc() -> str:
 
 
 def hoje() -> str:
+    """Dia corrente em UTC.
+
+    Não usar em `gerado_em`: uma data pura não diz a hora, então quem exibe não
+    consegue converter para o fuso do leitor — um snapshot gerado às 23h de 29/07
+    em Brasília fica gravado como 30/07 e aparece assim para sempre. Os metadados
+    publicados usam `agora_utc()`, que preserva o instante.
+    """
     return datetime.now(timezone.utc).date().isoformat()
 
 
@@ -880,7 +887,7 @@ def transformar_legislacao(
                 "url_base": fonte["url"],
                 "total_artigos": len(artigos),
                 "version": "2.0",
-                "gerado_em": hoje(),
+                "gerado_em": agora_utc(),
                 "transformacao": "planalto_html_v1",
                 "registros_retidos_sem_correspondencia": retidos,
             }
@@ -982,7 +989,7 @@ def transformar_sumulas_stj(
             "total": len(sumulas),
             "ativas": status["ativa"],
             "canceladas": status["cancelada"],
-            "gerado_em": hoje(),
+            "gerado_em": agora_utc(),
             "descricao": "Súmulas STJ extraídas do catálogo oficial",
             "transformacao": "sumulas_stj_html_v1",
         },
@@ -1199,7 +1206,7 @@ def transformar_sumulas_stf(
         "tipo": "Súmulas Vinculantes" if vinculante else "sumulas",
         "tribunal": "STF",
         "total": len(sumulas),
-        "gerado_em": hoje(),
+        "gerado_em": agora_utc(),
         "descricao": "Súmulas extraídas do catálogo oficial do STF",
         "transformacao": "sumulas_stf_html_v1",
     }
@@ -1315,7 +1322,7 @@ def transformar_jt(
             "total_edicoes": len({int(item["edicao"]) for item in teses.values()}),
             "total_teses": len(teses),
             "ramos_direito": dict(sorted(ramos.items())),
-            "gerado_em": hoje(),
+            "gerado_em": agora_utc(),
             "descricao": "Jurisprudência em Teses extraída das páginas oficiais do STJ",
             "transformacao": "jt_stj_html_v1",
             "edicoes_retidas_sem_correspondencia": sorted(edicoes_retidas),


### PR DESCRIPTION
Quatro famílias (legislação, súmulas STJ, súmulas STF e Jurisprudência em Teses) gravavam `gerado_em` como **data pura em UTC**; as outras gravam instante ISO completo.

Data pura não diz a hora, então quem exibe não consegue converter para o fuso do leitor: um snapshot promovido às 23h de 29/07 em Brasília fica gravado como `2026-07-30` e aparece assim para sempre. É o que o site mostra hoje para súmulas do STF e teses.

Agora os quatro pontos usam `agora_utc()`, como o resto do pipeline. Efeito colateral bem-vindo: o monitor de legislação usa esse campo como `If-Modified-Since`, e um instante é mais preciso que a meia-noite implícita de uma data pura.

`hoje()` fica no módulo, sem uso, com a explicação de por que não serve para metadado publicado.

**Vale daqui em diante.** Os arquivos publicados só ganham o formato novo na próxima promoção com mudança real de conteúdo — não repromovi súmulas e teses só para ajustar um dia de exibição, porque promover sem diferença de conteúdo é justamente o ruído que o protocolo evita.

## Verificação

- contrato inalterado: `snapshots.schema.json` aceita string; auditoria e `gerar_snapshots` apenas repassam o valor;
- conferido na prática: `transformar` de `sumulas_stf` agora emite `2026-07-30T02:34:19+00:00` em vez de `2026-07-30`;
- 111 testes Python passando; auditoria estrita sem inconsistências.

🤖 Generated with [Claude Code](https://claude.com/claude-code)