### PR TITLE
chore(base): regrava o metadado de súmulas do STF e teses com o instante

### DIFF
--- a/base-juridica/snapshots.json
+++ b/base-juridica/snapshots.json
@@ -58,21 +58,18 @@
       "mudancas": null
     },
     "jt_stj.json": {
-      "versao": 2,
-      "sha256": "12cc8b13f6329c3503102b0204085af5056e97c2d2e360d4e968b66c5ead5fdf",
-      "gerado_em": "2026-07-30",
+      "versao": 3,
+      "sha256": "58142a1982e6d0749ea5189b948d170fd5a99ba7e0df99221e7cc1c784ea1d0b",
+      "gerado_em": "2026-07-30T02:37:36+00:00",
       "registros": 3508,
       "colecao": "teses",
       "mudancas": {
         "adicionados": 0,
         "removidos": 0,
-        "alterados": 2,
+        "alterados": 0,
         "amostra_adicionados": [],
         "amostra_removidos": [],
-        "amostra_alterados": [
-          "JT_045_T13",
-          "JT_087_T09"
-        ]
+        "amostra_alterados": []
       }
     },
     "lei_adct.json": {
@@ -4643,29 +4640,18 @@
       }
     },
     "sumulas_stf.json": {
-      "versao": 2,
-      "sha256": "4d54cf7b46aae8d0f9b6b78df4eec14386b478b54c2df1763f9a9ca0329de648",
-      "gerado_em": "2026-07-30",
+      "versao": 3,
+      "sha256": "ec4e493065e635313b62c81967ea432f954bd6604d8baba3aa6e88004e06376c",
+      "gerado_em": "2026-07-30T02:37:32+00:00",
       "registros": 736,
       "colecao": "sumulas",
       "mudancas": {
         "adicionados": 0,
         "removidos": 0,
-        "alterados": 51,
+        "alterados": 0,
         "amostra_adicionados": [],
         "amostra_removidos": [],
-        "amostra_alterados": [
-          "121",
-          "14",
-          "145",
-          "15",
-          "208",
-          "235",
-          "267",
-          "269",
-          "27",
-          "303"
-        ]
+        "amostra_alterados": []
       }
     },
     "sumulas_stj.json": {

--- a/ferramentas/pesquisa/vade-mecum/data/jt_stj.json
+++ b/ferramentas/pesquisa/vade-mecum/data/jt_stj.json
@@ -23,7 +23,7 @@
       "Não classificado": 138,
       "Orientações Jurisprudenciais": 71
     },
-    "gerado_em": "2026-07-30",
+    "gerado_em": "2026-07-30T02:37:36+00:00",
     "descricao": "Jurisprudência em Teses extraída das páginas oficiais do STJ",
     "transformacao": "jt_stj_html_v1",
     "edicoes_retidas_sem_correspondencia": [

--- a/ferramentas/pesquisa/vade-mecum/data/sumulas_stf.json
+++ b/ferramentas/pesquisa/vade-mecum/data/sumulas_stf.json
@@ -4,7 +4,7 @@
     "tipo": "sumulas",
     "tribunal": "STF",
     "total": 736,
-    "gerado_em": "2026-07-30",
+    "gerado_em": "2026-07-30T02:37:32+00:00",
     "descricao": "Súmulas extraídas do catálogo oficial do STF",
     "transformacao": "sumulas_stf_html_v1",
     "ativas": 724,

--- a/ferramentas/pesquisa/vade-mecum/data/sumulas_stf_keywords.json
+++ b/ferramentas/pesquisa/vade-mecum/data/sumulas_stf_keywords.json
@@ -21,9 +21,9 @@
     "fonte": {
       "arquivo": "sumulas_stf.json",
       "colecao": "sumulas",
-      "sha256": "4d54cf7b46aae8d0f9b6b78df4eec14386b478b54c2df1763f9a9ca0329de648",
+      "sha256": "ec4e493065e635313b62c81967ea432f954bd6604d8baba3aa6e88004e06376c",
       "total_registros": 736,
-      "gerado_em": "2026-07-30"
+      "gerado_em": "2026-07-30T02:37:32+00:00"
     },
     "relacao": {
       "chave": "numero",


### PR DESCRIPTION
Aplica a #18 aos dois arquivos que já tinham sido promovidos hoje com data pura: o `_meta.gerado_em` dizia `2026-07-30` para uma promoção feita às **23h05 de 29/07** em Brasília.

Não é ajuste cosmético. Com as duas datas no site, o card exibia **"atualizado 30 jul · conferido 29 jul"** — mudança depois da conferência, o que é incoerente e mina justamente a confiança que a exibição pretende transmitir.

## Como foi feito

Pelo pipeline, não à mão: retransformação dos mesmos brutos da execução `2026-07-29-completa` (nova execução `2026-07-29-meta`), validação OK e comparação com **+0 -0 ~0 registros** nos dois arquivos — só o metadado muda. Backup preservado pela promoção.

## Verificação

- índices derivados regenerados (o índice registra o SHA-256 da fonte, que muda junto com o metadado);
- `snapshots.json` atualizado (`jt_stj` v3, `sumulas_stf` v3), `--verificar` coerente em 285 arquivos;
- auditoria estrita sem inconsistências;
- 111 testes Python e 58 do motor passando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)