### PR TITLE
Adiciona teste para para_inteiro em construir_indice_geo

### DIFF
--- a/ferramentas/manutencao/tests/test_construir_indice_geo.py
+++ b/ferramentas/manutencao/tests/test_construir_indice_geo.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULO_PATH = ROOT / "ferramentas" / "manutencao" / "construir_indice_geo.py"
+SPEC = importlib.util.spec_from_file_location("construir_indice_geo", MODULO_PATH)
+assert SPEC and SPEC.loader
+construtor = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = construtor
+SPEC.loader.exec_module(construtor)
+
+
+class ParaInteiroTest(unittest.TestCase):
+    """Conversão de IPv4 em inteiro usada para montar as faixas do índice."""
+
+    def test_converte_ipv4_valido(self) -> None:
+        self.assertEqual(construtor.para_inteiro("1.2.3.4"), (1 << 24) | (2 << 16) | (3 << 8) | 4)
+
+    def test_endereco_zero(self) -> None:
+        self.assertEqual(construtor.para_inteiro("0.0.0.0"), 0)
+
+    def test_endereco_maximo(self) -> None:
+        self.assertEqual(construtor.para_inteiro("255.255.255.255"), 0xFFFFFFFF)
+
+    def test_ipv6_devolve_none(self) -> None:
+        self.assertIsNone(construtor.para_inteiro("2001:db8::1"))
+
+    def test_string_vazia_devolve_none(self) -> None:
+        self.assertIsNone(construtor.para_inteiro(""))
+
+    def test_octeto_fora_da_faixa_devolve_none(self) -> None:
+        self.assertIsNone(construtor.para_inteiro("1.2.3.256"))
+
+    def test_octeto_nao_numerico_devolve_none(self) -> None:
+        self.assertIsNone(construtor.para_inteiro("1.2.3.abc"))
+
+    def test_numero_insuficiente_de_octetos_devolve_none(self) -> None:
+        self.assertIsNone(construtor.para_inteiro("1.2.3"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Resumo
- `construir_indice_geo.py` é o único script em `ferramentas/manutencao/` sem cobertura de teste; os demais (`atualizar_base_juridica.py`, `gerar_snapshots.py`, `validar_integridade.py`, etc.) têm seus pares em `ferramentas/manutencao/tests/`.
- Adiciona `test_construir_indice_geo.py`, cobrindo `para_inteiro`, a função pura que converte um IPv4 em inteiro para montar as faixas do índice de geolocalização.
- Casos cobertos: IP válido, extremos (`0.0.0.0` e `255.255.255.255`), IPv6, string vazia, octeto fora da faixa (>255), octeto não numérico e número insuficiente de octetos.

## Plano de teste
- [x] `py -m unittest ferramentas.manutencao.tests.test_construir_indice_geo -v` — 8 testes, todos passando
- [x] `py -m unittest discover -s ferramentas/manutencao/tests` — mesma suíte antes e depois da mudança (as falhas pré-existentes não relacionadas continuam idênticas com ou sem este arquivo)